### PR TITLE
[Feat] 카카오 OAuth 로그인 API & 설문조사 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,19 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// implementation 'org.springframework.boot:spring-boot-starter-data-redis' // MVP 단계에서는 생략
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+	// JWT 관련 의존성 추가
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/ktb/marong/MarongApplication.java
+++ b/src/main/java/com/ktb/marong/MarongApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class MarongApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(MarongApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(MarongApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/ktb/marong/config/ObjectMapperConfig.java
+++ b/src/main/java/com/ktb/marong/config/ObjectMapperConfig.java
@@ -1,0 +1,17 @@
+package com.ktb.marong.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * ObjectMapper 설정
+ */
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/ktb/marong/config/RestTemplateConfig.java
+++ b/src/main/java/com/ktb/marong/config/RestTemplateConfig.java
@@ -1,0 +1,17 @@
+package com.ktb.marong.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * RestTemplate 설정
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/token/refresh").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/error").permitAll()
+                        .requestMatchers("/survey").authenticated()
                         // 인증이 필요한 API
                         .anyRequest().authenticated()
                 )
@@ -59,7 +60,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173", "https://marong.app"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173", "https://marong.app", "http://172.16.24.210:5173/auth"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "x-auth-token"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.ktb.marong.security.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://marong.app"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173", "https://marong.app"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "x-auth-token"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package com.ktb.marong.config;
+
+import com.ktb.marong.security.JwtAuthenticationFilter;
+import com.ktb.marong.security.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+/**
+ * Spring Security 보안 설정
+ * Spring Security 6 이상 버전에 맞게 설정 업데이트
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // Spring Security 6+ 방식으로 세션 관리 설정
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // Spring Security 6+ 방식으로 인증 규칙 설정
+                .authorizeHttpRequests(authorize -> authorize
+                        // 인증 없이 접근 가능한 API
+                        .requestMatchers("/auth/oauth/redirect-url").permitAll()
+                        .requestMatchers("/auth/oauth/callback").permitAll()
+                        .requestMatchers("/auth/token/refresh").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        // 인증이 필요한 API
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://marong.app"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "x-auth-token"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/ktb/marong/controller/AuthController.java
+++ b/src/main/java/com/ktb/marong/controller/AuthController.java
@@ -1,0 +1,82 @@
+package com.ktb.marong.controller;
+
+import com.ktb.marong.dto.request.auth.TokenRefreshRequestDto;
+import com.ktb.marong.dto.response.auth.LoginResponseDto;
+import com.ktb.marong.dto.response.auth.TokenRefreshResponseDto;
+import com.ktb.marong.dto.response.auth.UserResponseDto;
+import com.ktb.marong.dto.response.common.ApiResponse;
+import com.ktb.marong.security.CurrentUser;
+import com.ktb.marong.service.auth.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 인증 컨트롤러
+ * 로그인, 로그아웃, 토큰 갱신 등의 인증 관련 API를 제공
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 소셜 로그인 리디렉션 URL 요청
+     */
+    @GetMapping("/oauth/redirect-url")
+    public ResponseEntity<?> getOAuthRedirectUrl(@RequestParam String provider) {
+        log.info("OAuth 리디렉션 URL 요청: provider={}", provider);
+        String redirectUrl = authService.getOAuthRedirectUrl(provider);
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of("redirectUrl", redirectUrl),
+                "redirect_url_generated",
+                null
+        ));
+    }
+
+    /**
+     * 소셜 로그인 콜백 처리 (토큰 발급)
+     */
+    @GetMapping("/oauth/callback")
+    public ResponseEntity<?> oauthCallback(@RequestParam String provider, @RequestParam String code) {
+        log.info("OAuth 콜백 요청: provider={}, code={}", provider, code);
+        LoginResponseDto loginResponse = authService.socialLogin(provider, code);
+        return ResponseEntity.ok(ApiResponse.success(loginResponse, "login_success", null));
+    }
+
+    /**
+     * 로그인 사용자 정보 조회
+     */
+    @GetMapping("/user")
+    public ResponseEntity<?> getCurrentUser(@CurrentUser Long userId) {
+        log.info("사용자 정보 조회: userId={}", userId);
+        UserResponseDto userResponse = authService.getCurrentUser(userId);
+        return ResponseEntity.ok(ApiResponse.success(userResponse, "user_info_retrieved", null));
+    }
+
+    /**
+     * 로그아웃
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@CurrentUser Long userId) {
+        log.info("로그아웃 요청: userId={}", userId);
+        authService.logout(userId);
+        return ResponseEntity.ok(ApiResponse.success(null, "logout_success", null));
+    }
+
+    /**
+     * 토큰 재발급 (Refresh Token)
+     */
+    @PostMapping("/token/refresh")
+    public ResponseEntity<?> refreshToken(@RequestBody TokenRefreshRequestDto requestDto) {
+        log.info("토큰 재발급 요청");
+        TokenRefreshResponseDto refreshResponse = authService.refreshToken(requestDto);
+        return ResponseEntity.ok(ApiResponse.success(refreshResponse, "token_refreshed", null));
+    }
+}

--- a/src/main/java/com/ktb/marong/controller/SurveyController.java
+++ b/src/main/java/com/ktb/marong/controller/SurveyController.java
@@ -1,0 +1,73 @@
+package com.ktb.marong.controller;
+
+import com.ktb.marong.dto.request.survey.SurveyRequestDto;
+import com.ktb.marong.dto.response.common.ApiResponse;
+import com.ktb.marong.dto.response.survey.SurveyResponseDto;
+import com.ktb.marong.security.CurrentUser;
+import com.ktb.marong.service.survey.SurveyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 설문조사 관련 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/survey")
+public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    /**
+     * 사용자 설문 최초 제출
+     */
+    @PostMapping
+    public ResponseEntity<?> saveSurvey(@CurrentUser Long userId, @Valid @RequestBody SurveyRequestDto requestDto) {
+        log.info("설문 저장 요청: userId={}", userId);
+        Long savedUserId = surveyService.saveSurvey(userId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiResponse.success(
+                        savedUserId,
+                        "survey_saved",
+                        null
+                )
+        );
+    }
+
+    /**
+     * 사용자 설문 정보 조회
+     */
+    @GetMapping
+    public ResponseEntity<?> getSurvey(@CurrentUser Long userId) {
+        log.info("설문 조회 요청: userId={}", userId);
+        SurveyResponseDto response = surveyService.getSurvey(userId);
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        response,
+                        "survey_retrieved",
+                        null
+                )
+        );
+    }
+
+    /**
+     * 사용자 설문 정보 수정
+     */
+    @PutMapping
+    public ResponseEntity<?> updateSurvey(@CurrentUser Long userId, @Valid @RequestBody SurveyRequestDto requestDto) {
+        log.info("설문 수정 요청: userId={}", userId);
+        Long updatedUserId = surveyService.updateSurvey(userId, requestDto);
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        updatedUserId,
+                        "survey_updated",
+                        null
+                )
+        );
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/auth/RefreshToken.java
+++ b/src/main/java/com/ktb/marong/domain/auth/RefreshToken.java
@@ -1,0 +1,56 @@
+package com.ktb.marong.domain.auth;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * RefreshToken 엔티티
+ * 사용자의 리프레시 토큰을 저장하는 엔티티
+ * 리프레시 토큰은 JWT 액세스 토큰이 만료되었을 때 새로운 토큰을 발급받기 위해 사용
+ */
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Builder
+    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 리프레시 토큰 갱신
+     */
+    public void updateToken(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 리프레시 토큰 만료 여부 확인
+     */
+    public boolean isExpired() {
+        return expiresAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/survey/SurveyDislikedFood.java
+++ b/src/main/java/com/ktb/marong/domain/survey/SurveyDislikedFood.java
@@ -1,0 +1,44 @@
+package com.ktb.marong.domain.survey;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "SurveyDislikedFood")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SurveyDislikedFood {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "food_name", nullable = false, length = 100)
+    private String foodName;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public SurveyDislikedFood(User user, String foodName) {
+        this.user = user;
+        this.foodName = foodName;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/survey/SurveyHobby.java
+++ b/src/main/java/com/ktb/marong/domain/survey/SurveyHobby.java
@@ -1,0 +1,44 @@
+package com.ktb.marong.domain.survey;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "SurveyHobby")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SurveyHobby {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "hobby_name", nullable = false, length = 100)
+    private String hobbyName;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public SurveyHobby(User user, String hobbyName) {
+        this.user = user;
+        this.hobbyName = hobbyName;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/survey/SurveyLikedFood.java
+++ b/src/main/java/com/ktb/marong/domain/survey/SurveyLikedFood.java
@@ -1,0 +1,44 @@
+package com.ktb.marong.domain.survey;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "SurveyLikedFood")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SurveyLikedFood {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "food_name", nullable = false, length = 100)
+    private String foodName;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public SurveyLikedFood(User user, String foodName) {
+        this.user = user;
+        this.foodName = foodName;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/survey/SurveyMBTI.java
+++ b/src/main/java/com/ktb/marong/domain/survey/SurveyMBTI.java
@@ -1,0 +1,69 @@
+package com.ktb.marong.domain.survey;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "SurveyMBTI")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SurveyMBTI {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "ei_score", nullable = false)
+    private Integer eiScore;
+
+    @Column(name = "sn_score", nullable = false)
+    private Integer snScore;
+
+    @Column(name = "tf_score", nullable = false)
+    private Integer tfScore;
+
+    @Column(name = "jp_score", nullable = false)
+    private Integer jpScore;
+
+    @Column(nullable = false, length = 10)
+    private String mbti;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public SurveyMBTI(User user, Integer eiScore, Integer snScore, Integer tfScore, Integer jpScore) {
+        this.user = user;
+        this.eiScore = eiScore;
+        this.snScore = snScore;
+        this.tfScore = tfScore;
+        this.jpScore = jpScore;
+        this.mbti = calculateMbti();
+    }
+
+    private String calculateMbti() {
+        String mbti = "";
+        mbti += (eiScore > 50) ? "E" : "I";
+        mbti += (snScore > 50) ? "N" : "S";
+        mbti += (tfScore > 50) ? "F" : "T";
+        mbti += (jpScore > 50) ? "P" : "J";
+        return mbti;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/user/User.java
+++ b/src/main/java/com/ktb/marong/domain/user/User.java
@@ -1,0 +1,90 @@
+package com.ktb.marong.domain.user;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * User 엔티티
+ * 마롱 서비스의 사용자 정보를 관리하는 엔티티
+ */
+@Entity
+@Table(name = "Users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "provider_id", nullable = false, unique = true)
+    private String providerId;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(name = "provider_name")
+    private String providerName;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column
+    private String status = "active";
+
+    @Column(name = "has_completed_survey")
+    private Boolean hasCompletedSurvey = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public User(String email, String providerId, String nickname, String providerName, String profileImageUrl) {
+        this.email = email;
+        this.providerId = providerId;
+        this.nickname = nickname;
+        this.providerName = providerName;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    /**
+     * 설문 완료 처리
+     */
+    public void completeInitialSurvey() {
+        this.hasCompletedSurvey = true;
+    }
+
+    /**
+     * 프로필 업데이트
+     */
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    /**
+     * 소프트 삭제 처리
+     */
+    public void softDelete() {
+        this.status = "deleted";
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ktb/marong/dto/request/auth/TokenRefreshRequestDto.java
+++ b/src/main/java/com/ktb/marong/dto/request/auth/TokenRefreshRequestDto.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.dto.request.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 토큰 리프레시 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/ktb/marong/dto/request/survey/SurveyRequestDto.java
+++ b/src/main/java/com/ktb/marong/dto/request/survey/SurveyRequestDto.java
@@ -1,0 +1,46 @@
+package com.ktb.marong.dto.request.survey;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SurveyRequestDto {
+
+    @NotNull(message = "ei_score는 필수입니다.")
+    @Min(value = 0, message = "ei_score는 0 이상이어야 합니다.")
+    @Max(value = 100, message = "ei_score는 100 이하이어야 합니다.")
+    private Integer eiScore;
+
+    @NotNull(message = "sn_score는 필수입니다.")
+    @Min(value = 0, message = "sn_score는 0 이상이어야 합니다.")
+    @Max(value = 100, message = "sn_score는 100 이하이어야 합니다.")
+    private Integer snScore;
+
+    @NotNull(message = "tf_score는 필수입니다.")
+    @Min(value = 0, message = "tf_score는 0 이상이어야 합니다.")
+    @Max(value = 100, message = "tf_score는 100 이하이어야 합니다.")
+    private Integer tfScore;
+
+    @NotNull(message = "jp_score는 필수입니다.")
+    @Min(value = 0, message = "jp_score는 0 이상이어야 합니다.")
+    @Max(value = 100, message = "jp_score는 100 이하이어야 합니다.")
+    private Integer jpScore;
+
+    @NotEmpty(message = "취미는 최소 1개 이상이어야 합니다.")
+    private List<String> hobbies;
+
+    @NotEmpty(message = "좋아하는 음식 목록은 필수입니다.")
+    private List<String> likedFoods;
+
+    @NotEmpty(message = "싫어하는 음식 목록은 필수입니다.")
+    private List<String> dislikedFoods;
+}

--- a/src/main/java/com/ktb/marong/dto/response/auth/KakaoUserInfoDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/auth/KakaoUserInfoDto.java
@@ -1,6 +1,5 @@
 package com.ktb.marong.dto.response.auth;
 
-import com.ktb.marong.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/ktb/marong/dto/response/auth/KakaoUserInfoDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/auth/KakaoUserInfoDto.java
@@ -1,0 +1,21 @@
+package com.ktb.marong.dto.response.auth;
+
+import com.ktb.marong.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 사용자 정보 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoUserInfoDto {
+    private String providerId;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/ktb/marong/dto/response/auth/LoginResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/auth/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package com.ktb.marong.dto.response.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String jwt;
+    private String refreshToken;
+    private boolean isNewUser;
+    private UserResponseDto user;
+}

--- a/src/main/java/com/ktb/marong/dto/response/auth/TokenRefreshResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/auth/TokenRefreshResponseDto.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.dto.response.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 토큰 리프레시 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshResponseDto {
+    private String jwt;
+}

--- a/src/main/java/com/ktb/marong/dto/response/auth/UserResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/auth/UserResponseDto.java
@@ -1,0 +1,35 @@
+package com.ktb.marong.dto.response.auth;
+
+import com.ktb.marong.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDto {
+    private Long userId;
+    private String kakaoName;
+    private String profileImage;
+    private String nickname;
+    private boolean hasCompletedSurvey;
+
+    /**
+     * User 엔티티로부터 UserResponseDto 생성
+     */
+    public static UserResponseDto fromEntity(User user) {
+        return UserResponseDto.builder()
+                .userId(user.getId())
+                .kakaoName(user.getNickname())
+                .profileImage(user.getProfileImageUrl())
+                .nickname(user.getNickname())
+                .hasCompletedSurvey(user.getHasCompletedSurvey())
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/marong/dto/response/common/ApiResponse.java
+++ b/src/main/java/com/ktb/marong/dto/response/common/ApiResponse.java
@@ -1,0 +1,43 @@
+package com.ktb.marong.dto.response.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * API 응답을 위한 공통 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private T data;
+    private String message;
+    private Map<String, Object> meta;
+
+    /**
+     * 성공 응답 생성
+     */
+    public static <T> ApiResponse<T> success(T data, String message, Map<String, Object> meta) {
+        return ApiResponse.<T>builder()
+                .data(data)
+                .message(message)
+                .meta(meta)
+                .build();
+    }
+
+    /**
+     * 에러 응답 생성
+     */
+    public static ApiResponse<Object> error(String code, String message) {
+        return ApiResponse.builder()
+                .data(null)
+                .message(message)
+                .meta(Map.of("code", code))
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/marong/dto/response/survey/SurveyResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/survey/SurveyResponseDto.java
@@ -1,0 +1,23 @@
+package com.ktb.marong.dto.response.survey;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SurveyResponseDto {
+
+    private Integer eiScore;
+    private Integer snScore;
+    private Integer tfScore;
+    private Integer jpScore;
+    private List<String> hobbies;
+    private List<String> likedFoods;
+    private List<String> dislikedFoods;
+}

--- a/src/main/java/com/ktb/marong/exception/CustomException.java
+++ b/src/main/java/com/ktb/marong/exception/CustomException.java
@@ -1,0 +1,23 @@
+package com.ktb.marong.exception;
+
+import lombok.Getter;
+
+/**
+ * 커스텀 예외 클래스
+ * 서비스 로직에서 발생하는 예외를 처리하기 위한 클래스
+ */
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
 
     // 설문조사 관련 에러
     SURVEY_NOT_FOUND(404, "설문 정보가 존재하지 않습니다."),
-    INVALID_SURVEY_FORMAT(400, "입력 형식이 잘못되었습니다.");
+    INVALID_SURVEY_FORMAT(400, "입력 형식이 잘못되었습니다."),
+    SURVEY_ALREADY_SUBMITTED(409, "이미 최초 설문 조사를 제출한 사용자입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.ktb.marong.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 에러 코드 열거형
+ * 서비스 전반에서 사용되는 에러 코드를 정의
+ */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 공통 에러
+    INTERNAL_SERVER_ERROR(500, "서버 오류입니다."),
+
+    // 인증 관련 에러
+    UNAUTHORIZED(401, "인증이 필요합니다."),
+    INVALID_TOKEN(403, "유효하지 않거나 만료된 토큰입니다."),
+    TOKEN_EXPIRED(403, "토큰이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(403, "유효하지 않은 refreshToken 입니다."),
+    MISSING_TOKEN(400, "refreshToken이 필요합니다."),
+
+    // 사용자 관련 에러
+    USER_NOT_FOUND(404, "사용자 조회에 실패하였습니다."),
+
+    // OAuth 관련 에러
+    INVALID_PROVIDER(400, "provider 값이 올바르지 않습니다."),
+    INVALID_KAKAO_CODE(400, "인가 코드가 유효하지 않습니다."),
+    SOCIAL_AUTH_FAILED(401, "소셜 인증에 실패했습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -27,7 +27,11 @@ public enum ErrorCode {
     // OAuth 관련 에러
     INVALID_PROVIDER(400, "provider 값이 올바르지 않습니다."),
     INVALID_KAKAO_CODE(400, "인가 코드가 유효하지 않습니다."),
-    SOCIAL_AUTH_FAILED(401, "소셜 인증에 실패했습니다.");
+    SOCIAL_AUTH_FAILED(401, "소셜 인증에 실패했습니다."),
+
+    // 설문조사 관련 에러
+    SURVEY_NOT_FOUND(404, "설문 정보가 존재하지 않습니다."),
+    INVALID_SURVEY_FORMAT(400, "입력 형식이 잘못되었습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/ktb/marong/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ktb/marong/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package com.ktb.marong.exception;
+
+import com.ktb.marong.dto.response.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 전역 예외 핸들러
+ * 컨트롤러에서 발생하는 예외를 처리하는 클래스
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * CustomException 처리
+     */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e) {
+        log.error("CustomException 발생: {}", e.getMessage());
+
+        ErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Object> response = ApiResponse.error(errorCode.name(), e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /**
+     * 유효성 검증 예외 처리
+     */
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<ApiResponse<Object>> handleValidationException(Exception e) {
+        log.error("유효성 검증 예외 발생: {}", e.getMessage());
+
+        Map<String, String> errorFields = new HashMap<>();
+
+        if (e instanceof MethodArgumentNotValidException) {
+            ((MethodArgumentNotValidException) e).getBindingResult().getFieldErrors()
+                    .forEach(error -> errorFields.put(error.getField(), error.getDefaultMessage()));
+        } else if (e instanceof BindException) {
+            ((BindException) e).getBindingResult().getFieldErrors()
+                    .forEach(error -> errorFields.put(error.getField(), error.getDefaultMessage()));
+        }
+
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("code", "INVALID_INPUT");
+        meta.put("errors", errorFields);
+
+        ApiResponse<Object> response = ApiResponse.builder()
+                .data(null)
+                .message("입력값이 올바르지 않습니다.")
+                .meta(meta)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    /**
+     * 기타 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+        log.error("예외 발생: {}", e.getMessage(), e);
+
+        ApiResponse<Object> response = ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 오류입니다.");
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/com/ktb/marong/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ktb/marong/repository/RefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.auth.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * RefreshToken 리포지토리
+ * 리프레시 토큰 CRUD 작업을 위한 리포지토리
+ */
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    /**
+     * 사용자 ID로 리프레시 토큰 조회
+     */
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    /**
+     * 토큰으로 리프레시 토큰 조회
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * 사용자 ID로 리프레시 토큰 삭제
+     */
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/ktb/marong/repository/SurveyDislikedFoodRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyDislikedFoodRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.survey.SurveyDislikedFood;
+import com.ktb.marong.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SurveyDislikedFoodRepository extends JpaRepository<SurveyDislikedFood, Long> {
+    List<SurveyDislikedFood> findAllByUser(User user);
+
+    void deleteAllByUser(User user);
+}

--- a/src/main/java/com/ktb/marong/repository/SurveyDislikedFoodRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyDislikedFoodRepository.java
@@ -3,13 +3,26 @@ package com.ktb.marong.repository;
 import com.ktb.marong.domain.survey.SurveyDislikedFood;
 import com.ktb.marong.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+/**
+ * 싫어하는 음식 설문 리포지토리
+ */
 @Repository
 public interface SurveyDislikedFoodRepository extends JpaRepository<SurveyDislikedFood, Long> {
+    // 사용자에 해당하는 모든 싫어하는 음식 조회
     List<SurveyDislikedFood> findAllByUser(User user);
 
+    // 사용자에 해당하는 모든 싫어하는 음식 삭제
     void deleteAllByUser(User user);
+
+    // 추가: 사용자 ID로 직접 삭제하는 메소드 (더 효율적인 삭제 처리)
+    @Modifying
+    @Query("DELETE FROM SurveyDislikedFood s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ktb/marong/repository/SurveyHobbyRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyHobbyRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.survey.SurveyHobby;
+import com.ktb.marong.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SurveyHobbyRepository extends JpaRepository<SurveyHobby, Long> {
+    List<SurveyHobby> findAllByUser(User user);
+
+    void deleteAllByUser(User user);
+}

--- a/src/main/java/com/ktb/marong/repository/SurveyHobbyRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyHobbyRepository.java
@@ -3,13 +3,26 @@ package com.ktb.marong.repository;
 import com.ktb.marong.domain.survey.SurveyHobby;
 import com.ktb.marong.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+/**
+ * 취미 설문 리포지토리
+ */
 @Repository
 public interface SurveyHobbyRepository extends JpaRepository<SurveyHobby, Long> {
+    // 사용자에 해당하는 모든 취미 조회
     List<SurveyHobby> findAllByUser(User user);
 
+    // 사용자에 해당하는 모든 취미 삭제
     void deleteAllByUser(User user);
+
+    // 추가: 사용자 ID로 직접 삭제하는 메소드 (더 효율적인 삭제 처리)
+    @Modifying
+    @Query("DELETE FROM SurveyHobby s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ktb/marong/repository/SurveyLikedFoodRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyLikedFoodRepository.java
@@ -3,13 +3,26 @@ package com.ktb.marong.repository;
 import com.ktb.marong.domain.survey.SurveyLikedFood;
 import com.ktb.marong.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+/**
+ * 좋아하는 음식 설문 리포지토리
+ */
 @Repository
 public interface SurveyLikedFoodRepository extends JpaRepository<SurveyLikedFood, Long> {
+    // 사용자에 해당하는 모든 좋아하는 음식 조회
     List<SurveyLikedFood> findAllByUser(User user);
 
+    // 사용자에 해당하는 모든 좋아하는 음식 삭제
     void deleteAllByUser(User user);
+
+    // 추가: 사용자 ID로 직접 삭제하는 메소드 (더 효율적인 삭제 처리)
+    @Modifying
+    @Query("DELETE FROM SurveyLikedFood s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ktb/marong/repository/SurveyLikedFoodRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyLikedFoodRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.survey.SurveyLikedFood;
+import com.ktb.marong.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SurveyLikedFoodRepository extends JpaRepository<SurveyLikedFood, Long> {
+    List<SurveyLikedFood> findAllByUser(User user);
+
+    void deleteAllByUser(User user);
+}

--- a/src/main/java/com/ktb/marong/repository/SurveyMBTIRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyMBTIRepository.java
@@ -3,13 +3,32 @@ package com.ktb.marong.repository;
 import com.ktb.marong.domain.survey.SurveyMBTI;
 import com.ktb.marong.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
+/**
+ * MBTI 설문 리포지토리
+ */
 @Repository
 public interface SurveyMBTIRepository extends JpaRepository<SurveyMBTI, Long> {
-    Optional<SurveyMBTI> findByUser(User user);
+    // 사용자에 해당하는 모든 MBTI 조회
+    List<SurveyMBTI> findAllByUser(User user);
 
-    void deleteByUser(User user);
+    // 사용자에 해당하는 모든 MBTI 삭제
+    void deleteAllByUser(User user);
+
+    // 추가: 사용자 ID로 직접 삭제하는 메소드 (더 효율적인 삭제 처리)
+    @Modifying
+    @Query("DELETE FROM SurveyMBTI s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+
+    // 추가: 사용자의 가장 최신 MBTI 정보 조회
+    SurveyMBTI findFirstByUserOrderByCreatedAtDesc(User user);
+
+    // 추가: 사용자 ID로 가장 최신 MBTI 정보 조회
+    SurveyMBTI findFirstByUser_IdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/ktb/marong/repository/SurveyMBTIRepository.java
+++ b/src/main/java/com/ktb/marong/repository/SurveyMBTIRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.survey.SurveyMBTI;
+import com.ktb.marong.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SurveyMBTIRepository extends JpaRepository<SurveyMBTI, Long> {
+    Optional<SurveyMBTI> findByUser(User user);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/ktb/marong/repository/UserRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserRepository.java
@@ -1,0 +1,35 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * User 리포지토리
+ * 사용자 CRUD 작업을 위한 리포지토리
+ */
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * 이메일로 사용자 조회
+     */
+    Optional<User> findByEmail(String email);
+
+    /**
+     * 제공자 ID로 사용자 조회
+     */
+    Optional<User> findByProviderId(String providerId);
+
+    /**
+     * 이메일 존재 여부 확인
+     */
+    boolean existsByEmail(String email);
+
+    /**
+     * 제공자 ID 존재 여부 확인
+     */
+    boolean existsByProviderId(String providerId);
+}

--- a/src/main/java/com/ktb/marong/security/CurrentUser.java
+++ b/src/main/java/com/ktb/marong/security/CurrentUser.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.security;
+
+import java.lang.annotation.*;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+/**
+ * 컨트롤러에서 현재 인증된 사용자의 ID를 주입받기 위한 어노테이션
+ */
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal(expression = "id")
+public @interface CurrentUser {
+}

--- a/src/main/java/com/ktb/marong/security/CurrentUser.java
+++ b/src/main/java/com/ktb/marong/security/CurrentUser.java
@@ -1,8 +1,8 @@
 package com.ktb.marong.security;
 
-import java.lang.annotation.*;
-
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
 
 /**
  * 컨트롤러에서 현재 인증된 사용자의 ID를 주입받기 위한 어노테이션

--- a/src/main/java/com/ktb/marong/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/marong/security/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.ktb.marong.security;
+
+import com.ktb.marong.service.auth.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터
+ * 모든 요청에 대해 JWT 토큰을 검증하고 인증 정보를 설정
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String jwt = jwtService.resolveToken(request);
+
+        if (jwt != null && jwtService.validateToken(jwt)) {
+            String userId = jwtService.getUserIdFromToken(jwt);
+
+            if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserById(Long.parseLong(userId));
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/ktb/marong/security/JwtExceptionFilter.java
+++ b/src/main/java/com/ktb/marong/security/JwtExceptionFilter.java
@@ -1,0 +1,47 @@
+package com.ktb.marong.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb.marong.dto.response.common.ApiResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 예외 처리 필터
+ * JWT 관련 예외를 처리하는 필터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            log.error("JWT 인증 예외 발생: {}", e.getMessage());
+            setErrorResponse(response, e);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, Exception e) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ApiResponse<Object> errorResponse = ApiResponse.error("UNAUTHORIZED", "인증 토큰이 필요합니다.");
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/ktb/marong/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/ktb/marong/security/UserDetailsServiceImpl.java
@@ -1,0 +1,38 @@
+package com.ktb.marong.security;
+
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 상세 서비스 구현
+ * Spring Security에서 사용자 정보를 로드하기 위한 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        return UserPrincipal.create(user);
+    }
+
+    /**
+     * ID로 사용자 정보 로드
+     */
+    public UserDetails loadUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + id));
+
+        return UserPrincipal.create(user);
+    }
+}

--- a/src/main/java/com/ktb/marong/security/UserPrincipal.java
+++ b/src/main/java/com/ktb/marong/security/UserPrincipal.java
@@ -1,0 +1,72 @@
+package com.ktb.marong.security;
+
+import com.ktb.marong.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Spring Security에서 사용자 정보를 담는 클래스
+ */
+@Getter
+@AllArgsConstructor
+public class UserPrincipal implements UserDetails {
+
+    private Long id;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    /**
+     * User 엔티티로부터 UserPrincipal 생성
+     */
+    public static UserPrincipal create(User user) {
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                authorities
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // OAuth2 인증이므로 비밀번호는 없음
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/ktb/marong/service/auth/AuthService.java
+++ b/src/main/java/com/ktb/marong/service/auth/AuthService.java
@@ -1,0 +1,133 @@
+package com.ktb.marong.service.auth;
+
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.request.auth.TokenRefreshRequestDto;
+import com.ktb.marong.dto.response.auth.KakaoUserInfoDto;
+import com.ktb.marong.dto.response.auth.LoginResponseDto;
+import com.ktb.marong.dto.response.auth.TokenRefreshResponseDto;
+import com.ktb.marong.dto.response.auth.UserResponseDto;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import com.ktb.marong.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 인증 서비스
+ * 로그인, 로그아웃, 토큰 갱신 등의 인증 관련 기능을 제공하는 서비스입니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    /**
+     * OAuth 리디렉션 URL 생성
+     */
+    public String getOAuthRedirectUrl(String provider) {
+        if (!"kakao".equals(provider)) {
+            throw new CustomException(ErrorCode.INVALID_PROVIDER);
+        }
+
+        return kakaoOAuthService.getRedirectUrl();
+    }
+
+    /**
+     * 소셜 로그인 처리
+     */
+    @Transactional
+    public LoginResponseDto socialLogin(String provider, String code) {
+        log.info("소셜 로그인 요청: provider={}, code={}", provider, code);
+
+        if (!"kakao".equals(provider)) {
+            throw new CustomException(ErrorCode.INVALID_PROVIDER);
+        }
+
+        try {
+            // 카카오 액세스 토큰 획득
+            String kakaoAccessToken = kakaoOAuthService.getAccessToken(code);
+
+            // 카카오 사용자 정보 획득
+            KakaoUserInfoDto userInfo = kakaoOAuthService.getUserInfo(kakaoAccessToken);
+
+            // 카카오 사용자 정보로 사용자 조회 또는 생성
+            User user = kakaoOAuthService.findOrCreateUser(userInfo);
+
+            // JWT 토큰 발급
+            String jwt = jwtService.createAccessToken(user);
+            String refreshToken = jwtService.createRefreshToken(user);
+
+            // 로그인 응답 생성
+            return LoginResponseDto.builder()
+                    .jwt(jwt)
+                    .refreshToken(refreshToken)
+                    .isNewUser(!user.getHasCompletedSurvey())
+                    .user(UserResponseDto.fromEntity(user))
+                    .build();
+        } catch (Exception e) {
+            log.error("소셜 로그인 처리 중 오류 발생", e);
+            throw new CustomException(ErrorCode.SOCIAL_AUTH_FAILED);
+        }
+    }
+
+    /**
+     * 토큰 리프레시
+     */
+    @Transactional
+    public TokenRefreshResponseDto refreshToken(TokenRefreshRequestDto requestDto) {
+        String refreshToken = requestDto.getRefreshToken();
+
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.MISSING_TOKEN);
+        }
+
+        // Refresh Token 유효성 검증
+        if (!jwtService.validateToken(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // Refresh Token에서 사용자 ID 추출
+        String userId = jwtService.getUserIdFromToken(refreshToken);
+
+        // 저장된 Refresh Token과 비교
+        if (!jwtService.validateRefreshToken(userId, refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 사용자 조회
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 새로운 Access Token 발급
+        String newAccessToken = jwtService.createAccessToken(user);
+
+        return new TokenRefreshResponseDto(newAccessToken);
+    }
+
+    /**
+     * 로그아웃 처리
+     */
+    @Transactional
+    public void logout(Long userId) {
+        // Refresh Token 삭제
+        jwtService.deleteRefreshToken(userId.toString());
+        log.info("로그아웃 처리 완료: userId={}", userId);
+    }
+
+    /**
+     * 로그인 사용자 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public UserResponseDto getCurrentUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return UserResponseDto.fromEntity(user);
+    }
+}

--- a/src/main/java/com/ktb/marong/service/auth/JwtService.java
+++ b/src/main/java/com/ktb/marong/service/auth/JwtService.java
@@ -1,0 +1,159 @@
+package com.ktb.marong.service.auth;
+
+import com.ktb.marong.domain.auth.RefreshToken;
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+/**
+ * JWT 토큰 서비스
+ * JWT 토큰 생성, 검증, 처리를 담당하는 서비스
+ */
+@Slf4j
+@Service
+public class JwtService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final SecretKey key;
+    private final long accessTokenValidity;
+    private final long refreshTokenValidity;
+
+    public JwtService(
+            RefreshTokenRepository refreshTokenRepository,
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-validity}") long accessTokenValidity,
+            @Value("${jwt.refresh-token-validity}") long refreshTokenValidity) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidity = accessTokenValidity;
+        this.refreshTokenValidity = refreshTokenValidity;
+    }
+
+    /**
+     * Access Token을 생성
+     */
+    public String createAccessToken(User user) {
+        return createToken(user.getId().toString(), user.getEmail(), accessTokenValidity);
+    }
+
+    /**
+     * Refresh Token을 생성하고 저장
+     */
+    @Transactional
+    public String createRefreshToken(User user) {
+        String token = createToken(user.getId().toString(), user.getEmail(), refreshTokenValidity);
+
+        // 토큰 만료일 계산
+        LocalDateTime expiresAt = LocalDateTime.now().plusNanos(refreshTokenValidity * 1000000);
+
+        // 기존 토큰이 있는지 조회하여 업데이트 또는 생성
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getId())
+                .map(rt -> {
+                    rt.updateToken(token, expiresAt);
+                    return rt;
+                })
+                .orElse(RefreshToken.builder()
+                        .userId(user.getId())
+                        .token(token)
+                        .expiresAt(expiresAt)
+                        .build());
+
+        refreshTokenRepository.save(refreshToken);
+
+        return token;
+    }
+
+    /**
+     * JWT 토큰을 생성
+     */
+    private String createToken(String subject, String email, long expireTime) {
+        Claims claims = Jwts.claims().setSubject(subject);
+        claims.put("email", email);
+
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expireTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * HTTP 요청에서 JWT 토큰을 추출
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * JWT 토큰의 유효성을 검증
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (Exception e) {
+            log.info("유효하지 않은 JWT 토큰입니다.");
+        }
+        return false;
+    }
+
+    /**
+     * JWT 토큰에서 사용자 ID를 추출
+     */
+    public String getUserIdFromToken(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰에서도 userId는 추출 가능
+            return e.getClaims().getSubject();
+        }
+    }
+
+    /**
+     * 저장된 Refresh Token과 일치하는지 확인
+     */
+    @Transactional(readOnly = true)
+    public boolean validateRefreshToken(String userId, String refreshToken) {
+        return refreshTokenRepository.findByUserId(Long.parseLong(userId))
+                .map(token -> !token.isExpired() && token.getToken().equals(refreshToken))
+                .orElse(false);
+    }
+
+    /**
+     * 저장된 Refresh Token을 삭제 (로그아웃 시 사용)
+     */
+    @Transactional
+    public void deleteRefreshToken(String userId) {
+        refreshTokenRepository.deleteByUserId(Long.parseLong(userId));
+    }
+}

--- a/src/main/java/com/ktb/marong/service/auth/KakaoOAuthService.java
+++ b/src/main/java/com/ktb/marong/service/auth/KakaoOAuthService.java
@@ -1,0 +1,169 @@
+package com.ktb.marong.service.auth;
+
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.response.auth.KakaoUserInfoDto;
+import com.ktb.marong.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * 카카오 OAuth 서비스
+ * 카카오 소셜 로그인 처리를 담당하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    private final RestTemplate restTemplate;
+    private final UserRepository userRepository;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    private String authorizationUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoUri;
+
+    /**
+     * 카카오 로그인 리디렉션 URL 생성
+     */
+    public String getRedirectUrl() {
+        return authorizationUri + "?client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&response_type=code";
+    }
+
+    /**
+     * 카카오 인증 코드를 통해 액세스 토큰을 얻음
+     */
+    public String getAccessToken(String code) {
+        log.info("카카오 액세스 토큰 요청: code={}", code);
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 파라미터 설정
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        // HTTP 요청 설정
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+        try {
+            // POST 요청 실행
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    tokenUri,
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    Map.class
+            );
+
+            log.info("카카오 액세스 토큰 응답: {}", response);
+            log.info("카카오 액세스 토큰 응답: {}", response.getBody());
+
+            // 응답에서 액세스 토큰 추출
+            return (String) response.getBody().get("access_token");
+        } catch (Exception e) {
+            log.error("카카오 액세스 토큰 요청 실패", e);
+            throw new RuntimeException("카카오 액세스 토큰 요청 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 카카오 액세스 토큰을 통해 사용자 정보를 얻음
+     */
+    public KakaoUserInfoDto getUserInfo(String accessToken) {
+        log.info("카카오 사용자 정보 요청: accessToken={}", accessToken);
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 설정
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+
+        try {
+            // GET 요청 실행
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    userInfoUri,
+                    HttpMethod.GET,
+                    kakaoUserInfoRequest,
+                    Map.class
+            );
+
+            log.info("카카오 사용자 정보 응답: {}", response.getBody());
+
+            // 응답에서 사용자 정보 추출
+            Map<String, Object> attributes = response.getBody();
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+            String providerId = String.valueOf(attributes.get("id"));
+            String email = (String) kakaoAccount.get("email");
+            String nickname = (String) profile.get("nickname");
+            String profileImageUrl = (String) profile.get("profile_image_url");
+
+            // 사용자 정보 DTO 생성
+            return new KakaoUserInfoDto(providerId, email, nickname, profileImageUrl);
+        } catch (Exception e) {
+            log.error("카카오 사용자 정보 요청 실패", e);
+            throw new RuntimeException("카카오 사용자 정보 요청 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 카카오 사용자 정보를 통해 신규 사용자를 등록하거나 기존 사용자를 찾음
+     */
+    @Transactional
+    public User findOrCreateUser(KakaoUserInfoDto userInfoDto) {
+        return userRepository.findByProviderId(userInfoDto.getProviderId())
+                .orElseGet(() -> createUser(userInfoDto));
+    }
+
+    /**
+     * 신규 사용자를 생성
+     */
+    private User createUser(KakaoUserInfoDto userInfoDto) {
+        log.info("신규 사용자 등록: {}", userInfoDto.getEmail());
+
+        User user = User.builder()
+                .email(userInfoDto.getEmail())
+                .providerId(userInfoDto.getProviderId())
+                .nickname(userInfoDto.getNickname())
+                .providerName("kakao")
+                .profileImageUrl(userInfoDto.getProfileImageUrl())
+                .build();
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/ktb/marong/service/auth/KakaoOAuthService.java
+++ b/src/main/java/com/ktb/marong/service/auth/KakaoOAuthService.java
@@ -129,12 +129,27 @@ public class KakaoOAuthService {
             Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
             String providerId = String.valueOf(attributes.get("id"));
-            String email = (String) kakaoAccount.get("email");
+
+            // 이메일 추출 (권한이 없는 경우 대체 값 사용)
+            String email = null;
+            if (kakaoAccount.containsKey("email") && kakaoAccount.get("email") != null) {
+                email = (String) kakaoAccount.get("email");
+            } else {
+                // 이메일 권한이 없는 경우 providerId를 사용하여 대체 이메일 생성
+                email = providerId + "@kakao.marong.com";
+                log.info("카카오 이메일 권한이 없어 대체 이메일 생성: {}", email);
+            }
+
             String nickname = (String) profile.get("nickname");
             String profileImageUrl = (String) profile.get("profile_image_url");
 
             // 사용자 정보 DTO 생성
-            return new KakaoUserInfoDto(providerId, email, nickname, profileImageUrl);
+            return KakaoUserInfoDto.builder()
+                    .providerId(providerId)
+                    .email(email)
+                    .nickname(nickname)
+                    .profileImageUrl(profileImageUrl)
+                    .build();
         } catch (Exception e) {
             log.error("카카오 사용자 정보 요청 실패", e);
             throw new RuntimeException("카카오 사용자 정보 요청 실패: " + e.getMessage());

--- a/src/main/java/com/ktb/marong/service/survey/SurveyService.java
+++ b/src/main/java/com/ktb/marong/service/survey/SurveyService.java
@@ -1,0 +1,183 @@
+package com.ktb.marong.service.survey;
+
+import com.ktb.marong.domain.survey.SurveyDislikedFood;
+import com.ktb.marong.domain.survey.SurveyHobby;
+import com.ktb.marong.domain.survey.SurveyLikedFood;
+import com.ktb.marong.domain.survey.SurveyMBTI;
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.request.survey.SurveyRequestDto;
+import com.ktb.marong.dto.response.survey.SurveyResponseDto;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import com.ktb.marong.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SurveyService {
+
+    private final UserRepository userRepository;
+    private final SurveyMBTIRepository surveyMBTIRepository;
+    private final SurveyHobbyRepository surveyHobbyRepository;
+    private final SurveyLikedFoodRepository surveyLikedFoodRepository;
+    private final SurveyDislikedFoodRepository surveyDislikedFoodRepository;
+
+    /**
+     * 사용자 설문 최초 제출
+     */
+    @Transactional
+    public Long saveSurvey(Long userId, SurveyRequestDto requestDto) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // MBTI 정보 저장
+        SurveyMBTI mbti = SurveyMBTI.builder()
+                .user(user)
+                .eiScore(requestDto.getEiScore())
+                .snScore(requestDto.getSnScore())
+                .tfScore(requestDto.getTfScore())
+                .jpScore(requestDto.getJpScore())
+                .build();
+        surveyMBTIRepository.save(mbti);
+
+        // 취미 정보 저장
+        List<SurveyHobby> hobbies = requestDto.getHobbies().stream()
+                .map(hobby -> SurveyHobby.builder()
+                        .user(user)
+                        .hobbyName(hobby)
+                        .build())
+                .collect(Collectors.toList());
+        surveyHobbyRepository.saveAll(hobbies);
+
+        // 좋아하는 음식 정보 저장
+        List<SurveyLikedFood> likedFoods = requestDto.getLikedFoods().stream()
+                .map(food -> SurveyLikedFood.builder()
+                        .user(user)
+                        .foodName(food)
+                        .build())
+                .collect(Collectors.toList());
+        surveyLikedFoodRepository.saveAll(likedFoods);
+
+        // 싫어하는 음식 정보 저장
+        List<SurveyDislikedFood> dislikedFoods = requestDto.getDislikedFoods().stream()
+                .map(food -> SurveyDislikedFood.builder()
+                        .user(user)
+                        .foodName(food)
+                        .build())
+                .collect(Collectors.toList());
+        surveyDislikedFoodRepository.saveAll(dislikedFoods);
+
+        // 설문 완료 처리
+        user.completeInitialSurvey();
+        userRepository.save(user);
+
+        return userId;
+    }
+
+    /**
+     * 사용자 설문 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public SurveyResponseDto getSurvey(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // MBTI 정보 조회
+        SurveyMBTI mbti = surveyMBTIRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND, "설문 정보가 존재하지 않습니다."));
+
+        // 취미 정보 조회
+        List<String> hobbies = surveyHobbyRepository.findAllByUser(user).stream()
+                .map(SurveyHobby::getHobbyName)
+                .collect(Collectors.toList());
+
+        // 좋아하는 음식 정보 조회
+        List<String> likedFoods = surveyLikedFoodRepository.findAllByUser(user).stream()
+                .map(SurveyLikedFood::getFoodName)
+                .collect(Collectors.toList());
+
+        // 싫어하는 음식 정보 조회
+        List<String> dislikedFoods = surveyDislikedFoodRepository.findAllByUser(user).stream()
+                .map(SurveyDislikedFood::getFoodName)
+                .collect(Collectors.toList());
+
+        return SurveyResponseDto.builder()
+                .eiScore(mbti.getEiScore())
+                .snScore(mbti.getSnScore())
+                .tfScore(mbti.getTfScore())
+                .jpScore(mbti.getJpScore())
+                .hobbies(hobbies)
+                .likedFoods(likedFoods)
+                .dislikedFoods(dislikedFoods)
+                .build();
+    }
+
+    /**
+     * 사용자 설문 정보 수정
+     */
+    @Transactional
+    public Long updateSurvey(Long userId, SurveyRequestDto requestDto) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 기존 설문 정보 존재 여부 확인
+        if (!surveyMBTIRepository.findByUser(user).isPresent()) {
+            throw new CustomException(ErrorCode.SURVEY_NOT_FOUND, "기존 설문 정보가 존재하지 않습니다.");
+        }
+
+        // 기존 설문 데이터 삭제
+        surveyMBTIRepository.deleteByUser(user);
+        surveyHobbyRepository.deleteAllByUser(user);
+        surveyLikedFoodRepository.deleteAllByUser(user);
+        surveyDislikedFoodRepository.deleteAllByUser(user);
+
+        // 새로운 MBTI 정보 저장
+        SurveyMBTI mbti = SurveyMBTI.builder()
+                .user(user)
+                .eiScore(requestDto.getEiScore())
+                .snScore(requestDto.getSnScore())
+                .tfScore(requestDto.getTfScore())
+                .jpScore(requestDto.getJpScore())
+                .build();
+        surveyMBTIRepository.save(mbti);
+
+        // 새로운 취미 정보 저장
+        List<SurveyHobby> hobbies = requestDto.getHobbies().stream()
+                .map(hobby -> SurveyHobby.builder()
+                        .user(user)
+                        .hobbyName(hobby)
+                        .build())
+                .collect(Collectors.toList());
+        surveyHobbyRepository.saveAll(hobbies);
+
+        // 새로운 좋아하는 음식 정보 저장
+        List<SurveyLikedFood> likedFoods = requestDto.getLikedFoods().stream()
+                .map(food -> SurveyLikedFood.builder()
+                        .user(user)
+                        .foodName(food)
+                        .build())
+                .collect(Collectors.toList());
+        surveyLikedFoodRepository.saveAll(likedFoods);
+
+        // 새로운 싫어하는 음식 정보 저장
+        List<SurveyDislikedFood> dislikedFoods = requestDto.getDislikedFoods().stream()
+                .map(food -> SurveyDislikedFood.builder()
+                        .user(user)
+                        .foodName(food)
+                        .build())
+                .collect(Collectors.toList());
+        surveyDislikedFoodRepository.saveAll(dislikedFoods);
+
+        return userId;
+    }
+}

--- a/src/main/java/com/ktb/marong/service/survey/SurveyService.java
+++ b/src/main/java/com/ktb/marong/service/survey/SurveyService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,12 @@ public class SurveyService {
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 기존 데이터가 있는 경우 모두 삭제 (중복 방지)
+        surveyMBTIRepository.deleteAllByUser(user);
+        surveyHobbyRepository.deleteAllByUser(user);
+        surveyLikedFoodRepository.deleteAllByUser(user);
+        surveyDislikedFoodRepository.deleteAllByUser(user);
 
         // MBTI 정보 저장
         SurveyMBTI mbti = SurveyMBTI.builder()
@@ -91,9 +98,16 @@ public class SurveyService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // MBTI 정보 조회
-        SurveyMBTI mbti = surveyMBTIRepository.findByUser(user)
-                .orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND, "설문 정보가 존재하지 않습니다."));
+        // MBTI 정보 조회 (변경된 부분)
+        List<SurveyMBTI> mbtiList = surveyMBTIRepository.findAllByUser(user);
+        if (mbtiList.isEmpty()) {
+            throw new CustomException(ErrorCode.SURVEY_NOT_FOUND, "설문 정보가 존재하지 않습니다.");
+        }
+
+        // 가장 최근에 생성된 MBTI 정보를 사용 (ID가 가장 큰 것)
+        SurveyMBTI mbti = mbtiList.stream()
+                .max(Comparator.comparing(SurveyMBTI::getId))
+                .orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND));
 
         // 취미 정보 조회
         List<String> hobbies = surveyHobbyRepository.findAllByUser(user).stream()
@@ -131,15 +145,24 @@ public class SurveyService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 기존 설문 정보 존재 여부 확인
-        if (!surveyMBTIRepository.findByUser(user).isPresent()) {
+        List<SurveyMBTI> mbtiList = surveyMBTIRepository.findAllByUser(user);
+        if (mbtiList.isEmpty()) {
             throw new CustomException(ErrorCode.SURVEY_NOT_FOUND, "기존 설문 정보가 존재하지 않습니다.");
         }
 
-        // 기존 설문 데이터 삭제
-        surveyMBTIRepository.deleteByUser(user);
+        // 기존 설문 데이터 삭제 (수정 전 명시적 삭제)
+        surveyMBTIRepository.deleteAllByUser(user);
+        // 삭제 후 flush를 추가해 삭제 작업이 즉시 데이터베이스에 반영되도록 함
+        surveyMBTIRepository.flush();
+
         surveyHobbyRepository.deleteAllByUser(user);
+        surveyHobbyRepository.flush();
+
         surveyLikedFoodRepository.deleteAllByUser(user);
+        surveyLikedFoodRepository.flush();
+
         surveyDislikedFoodRepository.deleteAllByUser(user);
+        surveyDislikedFoodRepository.flush();
 
         // 새로운 MBTI 정보 저장
         SurveyMBTI mbti = SurveyMBTI.builder()

--- a/src/main/java/com/ktb/marong/service/survey/SurveyService.java
+++ b/src/main/java/com/ktb/marong/service/survey/SurveyService.java
@@ -39,54 +39,65 @@ public class SurveyService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 기존 데이터가 있는 경우 모두 삭제 (중복 방지)
-        surveyMBTIRepository.deleteAllByUser(user);
-        surveyHobbyRepository.deleteAllByUser(user);
-        surveyLikedFoodRepository.deleteAllByUser(user);
-        surveyDislikedFoodRepository.deleteAllByUser(user);
+        // 이미 설문을 제출했는지 확인 (hasCompletedSurvey 플래그 확인)
+        if (user.getHasCompletedSurvey()) {
+            throw new CustomException(ErrorCode.SURVEY_ALREADY_SUBMITTED);
+        }
 
-        // MBTI 정보 저장
-        SurveyMBTI mbti = SurveyMBTI.builder()
-                .user(user)
-                .eiScore(requestDto.getEiScore())
-                .snScore(requestDto.getSnScore())
-                .tfScore(requestDto.getTfScore())
-                .jpScore(requestDto.getJpScore())
-                .build();
-        surveyMBTIRepository.save(mbti);
+        // MBTI 정보가 이미 존재하는지 확인
+        List<SurveyMBTI> existingMbtiList = surveyMBTIRepository.findAllByUser(user);
+        if (!existingMbtiList.isEmpty()) {
+            throw new CustomException(ErrorCode.SURVEY_ALREADY_SUBMITTED, "이미 MBTI 설문 정보가 존재합니다.");
+        }
 
-        // 취미 정보 저장
-        List<SurveyHobby> hobbies = requestDto.getHobbies().stream()
-                .map(hobby -> SurveyHobby.builder()
-                        .user(user)
-                        .hobbyName(hobby)
-                        .build())
-                .collect(Collectors.toList());
-        surveyHobbyRepository.saveAll(hobbies);
+        try {
+            // MBTI 정보 저장
+            SurveyMBTI mbti = SurveyMBTI.builder()
+                    .user(user)
+                    .eiScore(requestDto.getEiScore())
+                    .snScore(requestDto.getSnScore())
+                    .tfScore(requestDto.getTfScore())
+                    .jpScore(requestDto.getJpScore())
+                    .build();
+            surveyMBTIRepository.save(mbti);
 
-        // 좋아하는 음식 정보 저장
-        List<SurveyLikedFood> likedFoods = requestDto.getLikedFoods().stream()
-                .map(food -> SurveyLikedFood.builder()
-                        .user(user)
-                        .foodName(food)
-                        .build())
-                .collect(Collectors.toList());
-        surveyLikedFoodRepository.saveAll(likedFoods);
+            // 취미 정보 저장
+            List<SurveyHobby> hobbies = requestDto.getHobbies().stream()
+                    .map(hobby -> SurveyHobby.builder()
+                            .user(user)
+                            .hobbyName(hobby)
+                            .build())
+                    .collect(Collectors.toList());
+            surveyHobbyRepository.saveAll(hobbies);
 
-        // 싫어하는 음식 정보 저장
-        List<SurveyDislikedFood> dislikedFoods = requestDto.getDislikedFoods().stream()
-                .map(food -> SurveyDislikedFood.builder()
-                        .user(user)
-                        .foodName(food)
-                        .build())
-                .collect(Collectors.toList());
-        surveyDislikedFoodRepository.saveAll(dislikedFoods);
+            // 좋아하는 음식 정보 저장
+            List<SurveyLikedFood> likedFoods = requestDto.getLikedFoods().stream()
+                    .map(food -> SurveyLikedFood.builder()
+                            .user(user)
+                            .foodName(food)
+                            .build())
+                    .collect(Collectors.toList());
+            surveyLikedFoodRepository.saveAll(likedFoods);
 
-        // 설문 완료 처리
-        user.completeInitialSurvey();
-        userRepository.save(user);
+            // 싫어하는 음식 정보 저장
+            List<SurveyDislikedFood> dislikedFoods = requestDto.getDislikedFoods().stream()
+                    .map(food -> SurveyDislikedFood.builder()
+                            .user(user)
+                            .foodName(food)
+                            .build())
+                    .collect(Collectors.toList());
+            surveyDislikedFoodRepository.saveAll(dislikedFoods);
 
-        return userId;
+            // 설문 완료 처리
+            user.completeInitialSurvey();
+            userRepository.save(user);
+
+            return userId;
+        } catch (Exception e) {
+            // 기타 예외가 발생한 경우 로깅하고 서버 오류로 처리
+            log.error("설문 저장 중 오류 발생: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "설문 저장 중 오류가 발생했습니다.");
+        }
     }
 
     /**
@@ -150,57 +161,63 @@ public class SurveyService {
             throw new CustomException(ErrorCode.SURVEY_NOT_FOUND, "기존 설문 정보가 존재하지 않습니다.");
         }
 
-        // 기존 설문 데이터 삭제 (수정 전 명시적 삭제)
-        surveyMBTIRepository.deleteAllByUser(user);
-        // 삭제 후 flush를 추가해 삭제 작업이 즉시 데이터베이스에 반영되도록 함
-        surveyMBTIRepository.flush();
+        try {
+            // 기존 설문 데이터 삭제 (수정 전 명시적 삭제)
+            surveyMBTIRepository.deleteByUserId(userId);
+            // 삭제 후 flush를 추가해 삭제 작업이 즉시 데이터베이스에 반영되도록 함
+            surveyMBTIRepository.flush();
 
-        surveyHobbyRepository.deleteAllByUser(user);
-        surveyHobbyRepository.flush();
+            surveyHobbyRepository.deleteByUserId(userId);
+            surveyHobbyRepository.flush();
 
-        surveyLikedFoodRepository.deleteAllByUser(user);
-        surveyLikedFoodRepository.flush();
+            surveyLikedFoodRepository.deleteByUserId(userId);
+            surveyLikedFoodRepository.flush();
 
-        surveyDislikedFoodRepository.deleteAllByUser(user);
-        surveyDislikedFoodRepository.flush();
+            surveyDislikedFoodRepository.deleteByUserId(userId);
+            surveyDislikedFoodRepository.flush();
 
-        // 새로운 MBTI 정보 저장
-        SurveyMBTI mbti = SurveyMBTI.builder()
-                .user(user)
-                .eiScore(requestDto.getEiScore())
-                .snScore(requestDto.getSnScore())
-                .tfScore(requestDto.getTfScore())
-                .jpScore(requestDto.getJpScore())
-                .build();
-        surveyMBTIRepository.save(mbti);
+            // 새로운 MBTI 정보 저장
+            SurveyMBTI mbti = SurveyMBTI.builder()
+                    .user(user)
+                    .eiScore(requestDto.getEiScore())
+                    .snScore(requestDto.getSnScore())
+                    .tfScore(requestDto.getTfScore())
+                    .jpScore(requestDto.getJpScore())
+                    .build();
+            surveyMBTIRepository.save(mbti);
 
-        // 새로운 취미 정보 저장
-        List<SurveyHobby> hobbies = requestDto.getHobbies().stream()
-                .map(hobby -> SurveyHobby.builder()
-                        .user(user)
-                        .hobbyName(hobby)
-                        .build())
-                .collect(Collectors.toList());
-        surveyHobbyRepository.saveAll(hobbies);
+            // 새로운 취미 정보 저장
+            List<SurveyHobby> hobbies = requestDto.getHobbies().stream()
+                    .map(hobby -> SurveyHobby.builder()
+                            .user(user)
+                            .hobbyName(hobby)
+                            .build())
+                    .collect(Collectors.toList());
+            surveyHobbyRepository.saveAll(hobbies);
 
-        // 새로운 좋아하는 음식 정보 저장
-        List<SurveyLikedFood> likedFoods = requestDto.getLikedFoods().stream()
-                .map(food -> SurveyLikedFood.builder()
-                        .user(user)
-                        .foodName(food)
-                        .build())
-                .collect(Collectors.toList());
-        surveyLikedFoodRepository.saveAll(likedFoods);
+            // 새로운 좋아하는 음식 정보 저장
+            List<SurveyLikedFood> likedFoods = requestDto.getLikedFoods().stream()
+                    .map(food -> SurveyLikedFood.builder()
+                            .user(user)
+                            .foodName(food)
+                            .build())
+                    .collect(Collectors.toList());
+            surveyLikedFoodRepository.saveAll(likedFoods);
 
-        // 새로운 싫어하는 음식 정보 저장
-        List<SurveyDislikedFood> dislikedFoods = requestDto.getDislikedFoods().stream()
-                .map(food -> SurveyDislikedFood.builder()
-                        .user(user)
-                        .foodName(food)
-                        .build())
-                .collect(Collectors.toList());
-        surveyDislikedFoodRepository.saveAll(dislikedFoods);
+            // 새로운 싫어하는 음식 정보 저장
+            List<SurveyDislikedFood> dislikedFoods = requestDto.getDislikedFoods().stream()
+                    .map(food -> SurveyDislikedFood.builder()
+                            .user(user)
+                            .foodName(food)
+                            .build())
+                    .collect(Collectors.toList());
+            surveyDislikedFoodRepository.saveAll(dislikedFoods);
 
-        return userId;
+            return userId;
+        } catch (Exception e) {
+            // 기타 예외가 발생한 경우 로깅하고 서버 오류로 처리
+            log.error("설문 수정 중 오류 발생: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "설문 수정 중 오류가 발생했습니다.");
+        }
     }
 }

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -1,10 +1,46 @@
 # application.properties.template
+# 데이터베이스 설정
 spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:3306/${DB_NAME:marong}?useSSL=false&serverTimezone=UTC
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# JPA 설정
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.open-in-view=false
+
+# 서버 설정
+server.port=8080
+server.servlet.context-path=/api
+
+# 파일 업로드 설정
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
+# JWT 설정
+jwt.secret=${JWT_SECRET_KEY:marongSecretKeyForJwtSigningReplaceThisWithActualSecretInProduction}
+jwt.access-token-validity=3600000
+jwt.refresh-token-validity=604800000
+
+# 카카오 OAuth 설정
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID:your-kakao-client-id}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.redirect-uri=${KAKAO_REDIRECT_URI:http://localhost:8080/api/auth/oauth/callback?provider=kakao}
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# 로깅 설정
+logging.level.org.hibernate.SQL=debug
+logging.level.org.hibernate.type=trace
+logging.level.com.ktb.marong=debug


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 카카오 OAuth 로그인 관련 API 구현
  - 소셜 로그인 리디렉션 URL 요청
  - 소셜 로그인 callback 처리 (토큰 발급)
  - 로그인 사용자 정보 조회
  - 로그아웃
  - 토큰 재발급 (Refresh Token)
 - 설문조사 관련 API 구현
   - 사용자 설문 최초 제출
   - 사용자 설문 정보 조회
   - 사용자 설문 정보 수정


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 해결한 사항
  - 권한상 카카오 로그인에서 카카오계정(이메일) 정보를 못 받아오는 이슈 발생 -> 이메일 임의 생성 로직으로 해결
    - 추후 근본적인 해결책 생각 필요
  - CORS 에러 -> origin에 URI 추가하여 해결
  - 같은 사용자가 다시 로그인 후 설문조사 수정 및 조회 시 다중 레코드 존재 시에 생기는 NonUniqueResultException 오류 발생
    - 기존 deleteByUser 메서드를 deleteAllByUser로 변경하여 해당 사용자와 관련된 모든 데이터를 삭제
    - 기존 findByUser 메서드를 findAllByUser로 변경하여 단일 결과가 아닌 목록을 반환하도록 함
  - 사용자가 이미 최초 설문을 제출한 경우, 비즈니스 로직에서 먼저 검증하여 서버 오류가 아닌 명확한 409 에러 메시지 제공
- 추후 고려 사항
  - 카카오 로그인에서 받아올 수 있는 계정 정보 고려 필요


## 관련 이슈
- Resolved: #7
