### PR TITLE
[Feat] Feed (홈 페이지) API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/data.sql
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// AWS S3 의존성 추가
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ktb/marong/config/ObjectMapperConfig.java
+++ b/src/main/java/com/ktb/marong/config/ObjectMapperConfig.java
@@ -1,6 +1,8 @@
 package com.ktb.marong.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +14,9 @@ public class ObjectMapperConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // Java 21 (Java 8 이후 모든 버전) 날짜/시간 타입 지원
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식으로 날짜 출력
+        return objectMapper;
     }
 }

--- a/src/main/java/com/ktb/marong/config/S3Config.java
+++ b/src/main/java/com/ktb/marong/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.ktb.marong.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/marong/config/S3Config.java
+++ b/src/main/java/com/ktb/marong/config/S3Config.java
@@ -8,8 +8,10 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("prod") // 프로필이 prod일 때만 이 설정 적용
 public class S3Config {
 
     @Value("${cloud.aws.credentials.access-key}")

--- a/src/main/java/com/ktb/marong/config/WebConfig.java
+++ b/src/main/java/com/ktb/marong/config/WebConfig.java
@@ -1,0 +1,29 @@
+package com.ktb.marong.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.io.File;
+
+@Configuration
+@Profile("local")
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload.directory}")
+    private String uploadDir;
+
+    @Value("${file.upload.url.prefix}")
+    private String urlPrefix;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 프로젝트 루트 디렉토리 기준 절대 경로로 리소스 위치 설정
+        String resourcePath = System.getProperty("user.dir") + File.separator + uploadDir;
+
+        registry.addResourceHandler(urlPrefix + "/**")
+                .addResourceLocations("file:" + resourcePath);
+    }
+}

--- a/src/main/java/com/ktb/marong/controller/FeedController.java
+++ b/src/main/java/com/ktb/marong/controller/FeedController.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Map;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -30,10 +32,10 @@ public class FeedController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> uploadFeed(
             @CurrentUser Long userId,
-            @RequestPart(value = "missionId") Long missionId,
-            @RequestPart(value = "manittoName") String manittoName,
-            @RequestPart(value = "content") String content,
-            @RequestPart(value = "image", required = false) MultipartFile image) {
+            @RequestParam("missionId") Long missionId,
+            @RequestParam("manittoName") String manittoName,
+            @RequestParam("content") String content,
+            @RequestParam(value = "image", required = false) MultipartFile image) {
 
         log.info("게시글 업로드 요청: userId={}, missionId={}", userId, missionId);
 
@@ -42,7 +44,7 @@ public class FeedController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(
-                        feedId,
+                        Map.of("feedId", feedId),
                         "feed_uploaded",
                         null
                 ));

--- a/src/main/java/com/ktb/marong/controller/FeedController.java
+++ b/src/main/java/com/ktb/marong/controller/FeedController.java
@@ -1,0 +1,92 @@
+package com.ktb.marong.controller;
+
+import com.ktb.marong.dto.request.feed.PostLikeRequestDto;
+import com.ktb.marong.dto.request.feed.PostRequestDto;
+import com.ktb.marong.dto.response.common.ApiResponse;
+import com.ktb.marong.dto.response.feed.PostLikeResponseDto;
+import com.ktb.marong.dto.response.feed.PostPageResponseDto;
+import com.ktb.marong.security.CurrentUser;
+import com.ktb.marong.service.feed.FeedService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feeds")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    /**
+     * 게시글 업로드
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> uploadFeed(
+            @CurrentUser Long userId,
+            @RequestPart(value = "missionId") Long missionId,
+            @RequestPart(value = "manittoName") String manittoName,
+            @RequestPart(value = "content") String content,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        log.info("게시글 업로드 요청: userId={}, missionId={}", userId, missionId);
+
+        PostRequestDto requestDto = new PostRequestDto(missionId, manittoName, content);
+        Long feedId = feedService.savePost(userId, requestDto, image);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        feedId,
+                        "feed_uploaded",
+                        null
+                ));
+    }
+
+    /**
+     * 게시글 좋아요 등록/취소
+     */
+    @PostMapping("/{feedId}/likes")
+    public ResponseEntity<?> toggleLike(
+            @CurrentUser Long userId,
+            @PathVariable Long feedId,
+            @Valid @RequestBody PostLikeRequestDto requestDto) {
+
+        log.info("좋아요 요청: userId={}, feedId={}, cancel={}", userId, feedId, requestDto.getCancel());
+
+        PostLikeResponseDto response = feedService.toggleLike(userId, feedId, requestDto);
+
+        String message = requestDto.getCancel() ? "unlike_success" : "like_success";
+
+        return ResponseEntity.ok(ApiResponse.success(
+                response,
+                message,
+                null
+        ));
+    }
+
+    /**
+     * 게시글 목록 조회 (MVP에서는 그룹 필터링 없음)
+     */
+    @GetMapping
+    public ResponseEntity<?> getFeeds(
+            @CurrentUser Long userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+
+        log.info("피드 조회 요청: userId={}, page={}, pageSize={}", userId, page, pageSize);
+
+        PostPageResponseDto response = feedService.getPosts(page, pageSize);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                response,
+                "feeds_retrieved",
+                null
+        ));
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/feed/Post.java
+++ b/src/main/java/com/ktb/marong/domain/feed/Post.java
@@ -1,0 +1,74 @@
+package com.ktb.marong.domain.feed;
+
+import com.ktb.marong.domain.mission.Mission;
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Posts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE Posts SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // MVP에서는 모든 사용자가 하나의 그룹에 속하므로 group_id 필드는 고정값 사용
+    @Column(name = "group_id", nullable = false)
+    private Long groupId = 1L; // 기본 그룹 ID는 1로 고정
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Column(name = "anonymous_snapshot_name", nullable = false)
+    private String anonymousSnapshotName;
+
+    @Column(name = "manitto_name")
+    private String manittoName;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public Post(User user, Mission mission, String anonymousSnapshotName,
+                String manittoName, String content, String imageUrl) {
+        this.user = user;
+        this.mission = mission;
+        this.anonymousSnapshotName = anonymousSnapshotName;
+        this.manittoName = manittoName;
+        this.content = content;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/feed/PostLike.java
+++ b/src/main/java/com/ktb/marong/domain/feed/PostLike.java
@@ -1,0 +1,42 @@
+package com.ktb.marong.domain.feed;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "PostLikes", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_user_post", columnNames = {"user_id", "post_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PostLike(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/group/Group.java
+++ b/src/main/java/com/ktb/marong/domain/group/Group.java
@@ -1,0 +1,38 @@
+package com.ktb.marong.domain.group;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "`Groups`") // 백틱으로 감싸서 SQL 예약어 문제 해결
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "invite_code", nullable = false, unique = true)
+    private String inviteCode;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public Group(String name, String description, String inviteCode, String imageUrl) {
+        this.name = name;
+        this.description = description;
+        this.inviteCode = inviteCode;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/mission/Mission.java
+++ b/src/main/java/com/ktb/marong/domain/mission/Mission.java
@@ -1,0 +1,34 @@
+package com.ktb.marong.domain.mission;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "Missions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private String difficulty;
+
+    @Builder
+    public Mission(String title, String description, String difficulty) {
+        this.title = title;
+        this.description = description;
+        this.difficulty = difficulty;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/user/AnonymousName.java
+++ b/src/main/java/com/ktb/marong/domain/user/AnonymousName.java
@@ -1,0 +1,39 @@
+package com.ktb.marong.domain.user;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "AnonymousNames")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnonymousName {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // MVP에서는 모든 사용자가 그룹 ID 1에 속함
+    @Column(name = "group_id", nullable = false)
+    private Long groupId = 1L;
+
+    @Column(name = "anonymous_name", nullable = false)
+    private String anonymousName;
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @Builder
+    public AnonymousName(User user, String anonymousName, Integer week) {
+        this.user = user;
+        this.anonymousName = anonymousName;
+        this.week = week;
+    }
+}

--- a/src/main/java/com/ktb/marong/dto/request/feed/PostLikeRequestDto.java
+++ b/src/main/java/com/ktb/marong/dto/request/feed/PostLikeRequestDto.java
@@ -1,0 +1,15 @@
+package com.ktb.marong.dto.request.feed;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostLikeRequestDto {
+
+    @NotNull(message = "cancel 필드는 필수입니다.")
+    private Boolean cancel;
+}

--- a/src/main/java/com/ktb/marong/dto/request/feed/PostRequestDto.java
+++ b/src/main/java/com/ktb/marong/dto/request/feed/PostRequestDto.java
@@ -1,0 +1,26 @@
+package com.ktb.marong.dto.request.feed;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequestDto {
+
+    @NotNull(message = "미션 ID는 필수입니다.")
+    private Long missionId;
+
+    @NotBlank(message = "마니또 이름은 필수입니다.")
+    private String manittoName;
+
+    @NotBlank(message = "게시글 내용은 필수입니다.")
+    @Size(max = 300, message = "게시글 내용은 최대 300자까지 입력 가능합니다.")
+    private String content;
+
+    // 이미지는 MultipartFile로 별도 처리
+}

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostLikeResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostLikeResponseDto.java
@@ -1,0 +1,14 @@
+package com.ktb.marong.dto.response.feed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostLikeResponseDto {
+    private int likes;
+}

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostPageResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostPageResponseDto.java
@@ -1,0 +1,19 @@
+package com.ktb.marong.dto.response.feed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPageResponseDto {
+    private int page;
+    private int pageSize;
+    private int totalFeeds;
+    private List<PostResponseDto> feeds;
+}

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
@@ -1,0 +1,37 @@
+package com.ktb.marong.dto.response.feed;
+
+import com.ktb.marong.domain.feed.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponseDto {
+    private Long feedId;
+    private String author;
+    private String missionTitle;
+    private String manittoName;
+    private String content;
+    private int likes;
+    private LocalDateTime createdAt;
+    private String imageUrl;
+
+    public static PostResponseDto fromEntity(Post post, int likesCount) {
+        return PostResponseDto.builder()
+                .feedId(post.getId())
+                .author(post.getAnonymousSnapshotName())
+                .missionTitle(post.getMission().getTitle())
+                .manittoName(post.getManittoName())
+                .content(post.getContent())
+                .likes(likesCount)
+                .createdAt(post.getCreatedAt())
+                .imageUrl(post.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -32,7 +32,23 @@ public enum ErrorCode {
     // 설문조사 관련 에러
     SURVEY_NOT_FOUND(404, "설문 정보가 존재하지 않습니다."),
     INVALID_SURVEY_FORMAT(400, "입력 형식이 잘못되었습니다."),
-    SURVEY_ALREADY_SUBMITTED(409, "이미 최초 설문 조사를 제출한 사용자입니다.");
+    SURVEY_ALREADY_SUBMITTED(409, "이미 최초 설문 조사를 제출한 사용자입니다."),
+
+    // 게시글 관련 에러
+    FEED_NOT_FOUND(404, "게시글을 찾을 수 없습니다."),
+    MISSION_ALREADY_COMPLETED(409, "이미 해당 미션을 완료했습니다."),
+    ANONYMOUS_NAME_NOT_FOUND(404, "익명 이름을 찾을 수 없습니다."),
+    ALREADY_LIKED(409, "이미 좋아요한 게시글입니다."),
+    NOT_LIKED(409, "좋아요하지 않은 게시글입니다."),
+
+    // 파일 관련 에러
+    EMPTY_FILE(400, "빈 파일은 업로드할 수 없습니다."),
+    INVALID_FILE_FORMAT(400, "지원하지 않는 파일 형식입니다."),
+    FILE_TOO_LARGE(413, "업로드 가능한 파일 크기를 초과했습니다."),
+    FILE_UPLOAD_ERROR(500, "파일 업로드에 실패했습니다."),
+
+    // 미션 관련 에러
+    MISSION_NOT_FOUND(404, "미션을 찾을 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/ktb/marong/repository/AnonymousNameRepository.java
+++ b/src/main/java/com/ktb/marong/repository/AnonymousNameRepository.java
@@ -1,0 +1,16 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.user.AnonymousName;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AnonymousNameRepository extends JpaRepository<AnonymousName, Long> {
+
+    @Query("SELECT a.anonymousName FROM AnonymousName a WHERE a.user.id = :userId AND a.groupId = 1")
+    Optional<String> findAnonymousNameByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/ktb/marong/repository/GroupRepository.java
+++ b/src/main/java/com/ktb/marong/repository/GroupRepository.java
@@ -1,0 +1,11 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.group.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+    // 기본적인 CRUD 메서드는 JpaRepository에서 제공됨
+    // MVP 단계에서는 추가 쿼리 메서드는 필요하지 않음
+}

--- a/src/main/java/com/ktb/marong/repository/MissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/MissionRepository.java
@@ -1,0 +1,9 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.mission.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/com/ktb/marong/repository/PostLikeRepository.java
+++ b/src/main/java/com/ktb/marong/repository/PostLikeRepository.java
@@ -1,0 +1,24 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.feed.Post;
+import com.ktb.marong.domain.feed.PostLike;
+import com.ktb.marong.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    Optional<PostLike> findByUserAndPost(User user, Post post);
+
+    boolean existsByUserAndPost(User user, Post post);
+
+    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.post.id = :postId")
+    int countByPostId(@Param("postId") Long postId);
+
+    void deleteByUserAndPost(User user, Post post);
+}

--- a/src/main/java/com/ktb/marong/repository/PostRepository.java
+++ b/src/main/java/com/ktb/marong/repository/PostRepository.java
@@ -1,0 +1,20 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.feed.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // MVP에서는 모든 게시글을 최신순으로 가져옴 (그룹 필터링 없음)
+    @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.user.id = :userId AND p.mission.id = :missionId")
+    int countByUserIdAndMissionId(@Param("userId") Long userId, @Param("missionId") Long missionId);
+}

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -1,0 +1,161 @@
+package com.ktb.marong.service.feed;
+
+import com.ktb.marong.domain.feed.Post;
+import com.ktb.marong.domain.feed.PostLike;
+import com.ktb.marong.domain.mission.Mission;
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.request.feed.PostLikeRequestDto;
+import com.ktb.marong.dto.request.feed.PostRequestDto;
+import com.ktb.marong.dto.response.feed.PostLikeResponseDto;
+import com.ktb.marong.dto.response.feed.PostPageResponseDto;
+import com.ktb.marong.dto.response.feed.PostResponseDto;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import com.ktb.marong.repository.*;
+import com.ktb.marong.service.file.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final UserRepository userRepository;
+    private final MissionRepository missionRepository;
+    private final AnonymousNameRepository anonymousNameRepository;
+    private final FileService fileService;
+
+    /**
+     * 게시글 업로드
+     */
+    @Transactional
+    public Long savePost(Long userId, PostRequestDto requestDto, MultipartFile image) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 미션 조회
+        Mission mission = missionRepository.findById(requestDto.getMissionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
+
+        // 해당 미션을 이미 수행했는지 확인
+        if (postRepository.countByUserIdAndMissionId(userId, requestDto.getMissionId()) > 0) {
+            throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED);
+        }
+
+        // 사용자의 익명 이름 조회 (MVP에서는 그룹 ID가 1로 고정)
+        String anonymousName = anonymousNameRepository.findAnonymousNameByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ANONYMOUS_NAME_NOT_FOUND));
+
+        // 이미지 업로드 처리
+        String imageUrl = null;
+        if (image != null && !image.isEmpty()) {
+            imageUrl = fileService.uploadImage(image, "feeds");
+        }
+
+        // 게시글 생성
+        Post post = Post.builder()
+                .user(user)
+                .mission(mission)
+                .anonymousSnapshotName(anonymousName)
+                .manittoName(requestDto.getManittoName())
+                .content(requestDto.getContent())
+                .imageUrl(imageUrl)
+                .build();
+
+        // 게시글 저장
+        Post savedPost = postRepository.save(post);
+
+        // 미션 완료 상태 업데이트 (UserMission 테이블)
+        updateMissionStatus(userId, mission.getId());
+
+        return savedPost.getId();
+    }
+
+    /**
+     * 게시글 좋아요 등록/취소
+     */
+    @Transactional
+    public PostLikeResponseDto toggleLike(Long userId, Long feedId, PostLikeRequestDto requestDto) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 게시글 조회
+        Post post = postRepository.findById(feedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEED_NOT_FOUND));
+
+        boolean isCancel = requestDto.getCancel();
+
+        if (isCancel) {
+            // 좋아요 취소
+            PostLike postLike = postLikeRepository.findByUserAndPost(user, post)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_LIKED));
+
+            postLikeRepository.delete(postLike);
+            log.info("좋아요 취소 처리: userId={}, feedId={}", userId, feedId);
+        } else {
+            // 좋아요 등록
+            if (postLikeRepository.existsByUserAndPost(user, post)) {
+                throw new CustomException(ErrorCode.ALREADY_LIKED);
+            }
+
+            PostLike postLike = PostLike.builder()
+                    .user(user)
+                    .post(post)
+                    .build();
+
+            postLikeRepository.save(postLike);
+            log.info("좋아요 등록 처리: userId={}, feedId={}", userId, feedId);
+        }
+
+        // 현재 게시글의 좋아요 수 조회
+        int likeCount = postLikeRepository.countByPostId(feedId);
+
+        return new PostLikeResponseDto(likeCount);
+    }
+
+    /**
+     * 게시글 목록 조회 (MVP에서는 그룹 필터링 없이 모든 게시글 조회)
+     */
+    @Transactional(readOnly = true)
+    public PostPageResponseDto getPosts(int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+        Page<Post> postPage = postRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+        List<PostResponseDto> postDtos = postPage.getContent().stream()
+                .map(post -> {
+                    int likeCount = postLikeRepository.countByPostId(post.getId());
+                    return PostResponseDto.fromEntity(post, likeCount);
+                })
+                .collect(Collectors.toList());
+
+        return PostPageResponseDto.builder()
+                .page(page)
+                .pageSize(pageSize)
+                .totalFeeds((int) postPage.getTotalElements())
+                .feeds(postDtos)
+                .build();
+    }
+
+    /**
+     * 미션 완료 상태 업데이트
+     */
+    private void updateMissionStatus(Long userId, Long missionId) {
+        // UserMission 테이블에서 미션 상태를 'completed'로 업데이트
+        // MVP에서는 간소화하여 실제 구현 생략 가능
+        log.info("미션 완료 상태 업데이트: userId={}, missionId={}", userId, missionId);
+    }
+}

--- a/src/main/java/com/ktb/marong/service/file/FileService.java
+++ b/src/main/java/com/ktb/marong/service/file/FileService.java
@@ -1,0 +1,81 @@
+package com.ktb.marong.service.file;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 이미지 파일 업로드
+     */
+    public String uploadImage(MultipartFile file, String dirName) {
+        // 파일 검증
+        validateFile(file);
+
+        // 원본 파일명
+        String originalFileName = file.getOriginalFilename();
+        // 파일 확장자 추출
+        String ext = originalFileName.substring(originalFileName.lastIndexOf("."));
+        // 저장할 파일명 (UUID)
+        String savedFileName = UUID.randomUUID().toString() + ext;
+        // 저장 경로
+        String filePath = dirName + "/" + savedFileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            // S3에 업로드
+            amazonS3.putObject(
+                    new PutObjectRequest(bucket, filePath, inputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+        } catch (IOException e) {
+            log.error("파일 업로드 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+
+        // 업로드된 파일의 S3 URL 반환
+        return amazonS3.getUrl(bucket, filePath).toString();
+    }
+
+    /**
+     * 파일 유효성 검사
+     */
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new CustomException(ErrorCode.EMPTY_FILE);
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || (!contentType.startsWith("image/jpeg") && !contentType.startsWith("image/png"))) {
+            throw new CustomException(ErrorCode.INVALID_FILE_FORMAT);
+        }
+
+        if (file.getSize() > 2 * 1024 * 1024) { // 2MB 제한
+            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
+        }
+    }
+}

--- a/src/main/java/com/ktb/marong/service/file/FileUploadService.java
+++ b/src/main/java/com/ktb/marong/service/file/FileUploadService.java
@@ -1,0 +1,8 @@
+package com.ktb.marong.service.file;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+
+public interface FileUploadService {
+    String uploadFile(MultipartFile file, String dirName) throws IOException;
+}

--- a/src/main/java/com/ktb/marong/service/file/LocalFileUploadService.java
+++ b/src/main/java/com/ktb/marong/service/file/LocalFileUploadService.java
@@ -1,0 +1,63 @@
+package com.ktb.marong.service.file;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Profile("local")
+public class LocalFileUploadService implements FileUploadService {
+
+    @Value("${file.upload.directory}")
+    private String uploadDir;
+
+    @Value("${file.upload.url.prefix}")
+    private String urlPrefix;
+
+    @Override
+    public String uploadFile(MultipartFile file, String dirName) throws IOException {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        // 원본 파일명에서 확장자 추출
+        String originalFilename = file.getOriginalFilename();
+        String extension = StringUtils.getFilenameExtension(originalFilename);
+
+        // 파일명 중복 방지를 위한 UUID 생성
+        String fileName = UUID.randomUUID().toString() + "." + extension;
+
+        // 디렉토리 경로 생성 (절대 경로 사용)
+        // 현재 경로에 uploadDir과 dirName을 붙여서 절대 경로 생성
+        String directory = System.getProperty("user.dir") + File.separator + uploadDir + dirName;
+        Path directoryPath = Paths.get(directory);
+
+        // 디렉토리가 존재하지 않으면 생성
+        if (!Files.exists(directoryPath)) {
+            Files.createDirectories(directoryPath);
+        }
+
+        // 파일 저장 경로 설정
+        String filePath = directory + File.separator + fileName;
+        Path targetPath = Paths.get(filePath);
+
+        // 파일 저장
+        file.transferTo(targetPath.toFile());
+
+        log.info("파일 저장 완료: {}", filePath);
+
+        // 접근 가능한 URL 경로 반환 (웹에서 접근할 수 있는 경로)
+        return urlPrefix + dirName + "/" + fileName;
+    }
+}

--- a/src/main/java/com/ktb/marong/service/file/S3FileUploadService.java
+++ b/src/main/java/com/ktb/marong/service/file/S3FileUploadService.java
@@ -4,11 +4,10 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.ktb.marong.exception.CustomException;
-import com.ktb.marong.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,20 +17,21 @@ import java.util.UUID;
 
 @Slf4j
 @Service
+@Profile("prod")
 @RequiredArgsConstructor
-public class FileService {
+public class S3FileUploadService implements FileUploadService {
 
     private final AmazonS3 amazonS3;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    /**
-     * 이미지 파일 업로드
-     */
-    public String uploadImage(MultipartFile file, String dirName) {
+    @Override
+    public String uploadFile(MultipartFile file, String dirName) throws IOException {
         // 파일 검증
-        validateFile(file);
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
 
         // 원본 파일명
         String originalFileName = file.getOriginalFilename();
@@ -52,30 +52,9 @@ public class FileService {
                     new PutObjectRequest(bucket, filePath, inputStream, metadata)
                             .withCannedAcl(CannedAccessControlList.PublicRead)
             );
-        } catch (IOException e) {
-            log.error("파일 업로드 실패: {}", e.getMessage());
-            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
         }
 
         // 업로드된 파일의 S3 URL 반환
         return amazonS3.getUrl(bucket, filePath).toString();
-    }
-
-    /**
-     * 파일 유효성 검사
-     */
-    private void validateFile(MultipartFile file) {
-        if (file.isEmpty()) {
-            throw new CustomException(ErrorCode.EMPTY_FILE);
-        }
-
-        String contentType = file.getContentType();
-        if (contentType == null || (!contentType.startsWith("image/jpeg") && !contentType.startsWith("image/png"))) {
-            throw new CustomException(ErrorCode.INVALID_FILE_FORMAT);
-        }
-
-        if (file.getSize() > 2 * 1024 * 1024) { // 2MB 제한
-            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
-        }
     }
 }

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -1,3 +1,6 @@
+# Application 설정
+spring.application.name=marong
+
 # application.properties.template
 # 데이터베이스 설정
 spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:3306/${DB_NAME:marong}?useSSL=false&serverTimezone=UTC
@@ -44,3 +47,18 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.type=trace
 logging.level.com.ktb.marong=debug
+
+# JPA 배치 처리 최적화 설정
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+
+# AWS S3 설정
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false
+cloud.aws.s3.bucket=${S3_BUCKET_NAME}
+
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- Feed (홈 페이지) 관련 API 구현
  - 게시물 작성
    - 이미지 업로드 관련: 개발용 로컬 파일 시스템 업로드와 운영용 AWS S3 업로드 분리 구현
  - 게시물 목록 조회 (그룹별)
    - MVP에서는 모든 사용자의 그룹을 1개로 고정
  - 게시물 좋아요 등록 / 취소


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 개발 시 고려한 사항
  - MVP 개발 단계이므로,
    - 그룹 기능 간소화: 모든 사용자는 기본 그룹(ID: 1)에 속하도록 고정
    - 피드 조회 시 그룹 필터링 제거: 모든 게시글을 시간 순으로 조회
    - 게시글 작성 시 그룹 ID 파라미터 제거: 기본 그룹으로 자동 설정
    - 익명 이름 조회 시 그룹 필터링 제거: 사용자 ID로만 익명 이름 조회
    - 미션 선택 X: 임의로 사용마다 하루에 1개씩 미션 배정
  - 게시글 작성 API에서 이미지 업로드
    - 개발/테스트 환경에서는 로컬 파일 시스템을 사용하고, 실제 운영 환경에서는 S3를 사용하는 방식으로 구현
      - 로컬 프로필과 운영 프로필 분리 설정
- 해결한 사항
  - 이미지 업로드 관련해서 로컬 프로필과 운영 프로필을 분리하는 과정에서 S3Config 클래스가 프로필과 상관없이 항상 로드되는 에러 발생
    - S3Config 클래스에 @ Profile("prod") 어노테이션을 추가하여 prod 프로필에서만 로드되도록 변경
    - 로컬 파일 시스템 접근을 위한 WebConfig 추가
  - 게시글 작성 API에서 multipart/form-data 요청이 제대로 처리되지 않는 이슈 발생
    -  FeedController.java의 uploadFeed 메서드를 수정하여 multipart/form-data 요청을 올바르게 처리하도록 변경
  - 게시글 목록 조회 API에서 Jackson에서 LocalDateTime을 처리 못하는 문제 발생
    - ObjectMapperConfig.java 파일을 수정하여 Jackson에서 Java 8의 날짜/시간 타입(LocalDateTime)을 처리할 수 있는 모듈(jackson-datatype-jsr310) 등록
- 추후 고려 사항
  - FeedService에서 updateMissionStatus 함수 → 추후에 UserMission 테이블과 연동하여 미션 상태를 'completed'로 업데이트하는 기능 구현 필요


## 관련 이슈
- Resolved: #8 
