### PR TITLE
[Feat] 마니또 API 구현

### DIFF
--- a/src/main/java/com/ktb/marong/common/util/WeekCalculator.java
+++ b/src/main/java/com/ktb/marong/common/util/WeekCalculator.java
@@ -1,0 +1,27 @@
+package com.ktb.marong.common.util;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public class WeekCalculator {
+
+    // 누적 주차수 계산하기 위한 기준 날짜 (2025년 1월 1일) (상수로 정의)
+    private static final LocalDate SERVICE_START_DATE = LocalDate.of(2025, 1, 1);
+
+    /**
+     * 2025.01.01 기준 현재 누적 주차 계산
+     */
+    public static int getCurrentWeek() {
+        LocalDate today = LocalDate.now();
+        long weeksBetween = ChronoUnit.WEEKS.between(SERVICE_START_DATE, today) + 1;
+        return (int) weeksBetween;
+    }
+
+    /**
+     * 특정 날짜의 누적 주차 계산
+     */
+    public static int getWeekOf(LocalDate date) {
+        long weeksBetween = ChronoUnit.WEEKS.between(SERVICE_START_DATE, date) + 1;
+        return (int) weeksBetween;
+    }
+}

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/oauth/redirect-url").permitAll()
                         .requestMatchers("/auth/oauth/callback").permitAll()
                         .requestMatchers("/auth/token/refresh").permitAll()
+                        .requestMatchers("/test/**").permitAll() // 테스트 API 접근 허용 추가
                         .requestMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/survey").authenticated()

--- a/src/main/java/com/ktb/marong/controller/FeedController.java
+++ b/src/main/java/com/ktb/marong/controller/FeedController.java
@@ -33,13 +33,12 @@ public class FeedController {
     public ResponseEntity<?> uploadFeed(
             @CurrentUser Long userId,
             @RequestParam("missionId") Long missionId,
-            @RequestParam("manittoName") String manittoName,
             @RequestParam("content") String content,
             @RequestParam(value = "image", required = false) MultipartFile image) {
 
         log.info("게시글 업로드 요청: userId={}, missionId={}", userId, missionId);
 
-        PostRequestDto requestDto = new PostRequestDto(missionId, manittoName, content);
+        PostRequestDto requestDto = new PostRequestDto(missionId, content);  // manittoName 제거
         Long feedId = feedService.savePost(userId, requestDto, image);
 
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/ktb/marong/controller/ManittoController.java
+++ b/src/main/java/com/ktb/marong/controller/ManittoController.java
@@ -1,0 +1,54 @@
+package com.ktb.marong.controller;
+
+import com.ktb.marong.dto.response.common.ApiResponse;
+import com.ktb.marong.dto.response.manitto.ManittoInfoResponseDto;
+import com.ktb.marong.security.CurrentUser;
+import com.ktb.marong.service.manitto.ManittoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/manitto")
+public class ManittoController {
+
+    private final ManittoService manittoService;
+
+    /**
+     * 현재 마니또 정보 조회
+     * MVP에서는 모든 사용자가 기본 그룹(ID: 1)에 속한다고 가정
+     */
+    @GetMapping
+    public ResponseEntity<?> getCurrentManitto(@CurrentUser Long userId) {
+        log.info("마니또 정보 요청: userId={}", userId);
+
+        ManittoInfoResponseDto response = manittoService.getCurrentManittoInfo(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                response,
+                "manitto_info_retrieved",
+                null
+        ));
+    }
+
+    /**
+     * 마니또 미션 상태 조회
+     */
+    @GetMapping("/missions")
+    public ResponseEntity<?> getMissionStatus(@CurrentUser Long userId) {
+        log.info("미션 상태 요청: userId={}", userId);
+
+        var response = manittoService.getMissionStatus(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                response,
+                "mission_status_retrieved",
+                null
+        ));
+    }
+}

--- a/src/main/java/com/ktb/marong/controller/ManittoController.java
+++ b/src/main/java/com/ktb/marong/controller/ManittoController.java
@@ -1,5 +1,6 @@
 package com.ktb.marong.controller;
 
+import com.ktb.marong.domain.mission.UserMission;
 import com.ktb.marong.dto.response.common.ApiResponse;
 import com.ktb.marong.dto.response.manitto.ManittoInfoResponseDto;
 import com.ktb.marong.security.CurrentUser;
@@ -8,8 +9,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -48,6 +52,26 @@ public class ManittoController {
         return ResponseEntity.ok(ApiResponse.success(
                 response,
                 "mission_status_retrieved",
+                null
+        ));
+    }
+
+    /**
+     * 새 미션 할당
+     */
+    @PostMapping("/missions/assign")
+    public ResponseEntity<?> assignNewMission(@CurrentUser Long userId) {
+        log.info("새 미션 할당 요청: userId={}", userId);
+
+        UserMission newMission = manittoService.assignNewMission(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of(
+                        "missionId", newMission.getMission().getId(),
+                        "title", newMission.getMission().getTitle(),
+                        "description", newMission.getMission().getDescription()
+                ),
+                "mission_assigned",
                 null
         ));
     }

--- a/src/main/java/com/ktb/marong/controller/TestController.java
+++ b/src/main/java/com/ktb/marong/controller/TestController.java
@@ -1,0 +1,62 @@
+package com.ktb.marong.controller;
+
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.response.common.ApiResponse;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import com.ktb.marong.repository.UserRepository;
+import com.ktb.marong.service.auth.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 테스트 전용 컨트롤러
+ * 로컬 환경에서 테스트를 위한 API 제공
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test")
+public class TestController {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    /**
+     * 테스트용 JWT 토큰 발급 API
+     * 실제 운영 환경에서는 비활성화 필요
+     */
+    @GetMapping("/token/{userId}")
+    public ResponseEntity<?> getTestToken(@PathVariable Long userId) {
+        log.info("테스트 토큰 요청: userId={}", userId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // JWT 토큰 생성
+        String accessToken = jwtService.createAccessToken(user);
+        String refreshToken = jwtService.createRefreshToken(user);
+
+        // 응답 데이터 구성
+        Map<String, Object> responseData = new HashMap<>();
+        responseData.put("userId", user.getId());
+        responseData.put("nickname", user.getNickname());
+        responseData.put("jwt", accessToken);
+        responseData.put("refreshToken", refreshToken);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                responseData,
+                "test_token_issued",
+                null
+        ));
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/manitto/Manitto.java
+++ b/src/main/java/com/ktb/marong/domain/manitto/Manitto.java
@@ -1,0 +1,41 @@
+package com.ktb.marong.domain.manitto;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "Manittos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Manitto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "giver_id", nullable = false)
+    private User giver;  // 마니띠 (현재 사용자)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;  // 마니또 (대상 사용자)
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @Builder
+    public Manitto(Long groupId, User giver, User receiver, Integer week) {
+        this.groupId = groupId;
+        this.giver = giver;
+        this.receiver = receiver;
+        this.week = week;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/mission/UserMission.java
+++ b/src/main/java/com/ktb/marong/domain/mission/UserMission.java
@@ -1,0 +1,63 @@
+package com.ktb.marong.domain.mission;
+
+import com.ktb.marong.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "UserMissions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId = 1L;  // MVP에서는 기본 그룹 ID를 1로 고정
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Column(name = "status", nullable = false)
+    private String status = "ing";  // 기본값: ing (진행 중)
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public UserMission(User user, Long groupId, Mission mission, Integer week) {
+        this.user = user;
+        this.groupId = groupId;
+        this.mission = mission;
+        this.week = week;
+    }
+
+    /**
+     * 미션 완료 처리
+     */
+    public void complete() {
+        this.status = "completed";
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/mission/UserMission.java
+++ b/src/main/java/com/ktb/marong/domain/mission/UserMission.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -38,6 +39,9 @@ public class UserMission {
     @Column(name = "week", nullable = false)
     private Integer week;
 
+    @Column(name = "assigned_date", nullable = false)
+    private LocalDate assignedDate;
+
     @CreationTimestamp
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -47,11 +51,12 @@ public class UserMission {
     private LocalDateTime updatedAt;
 
     @Builder
-    public UserMission(User user, Long groupId, Mission mission, Integer week) {
+    public UserMission(User user, Long groupId, Mission mission, Integer week, LocalDate assignedDate) {
         this.user = user;
         this.groupId = groupId;
         this.mission = mission;
         this.week = week;
+        this.assignedDate = assignedDate != null ? assignedDate : LocalDate.now();
     }
 
     /**

--- a/src/main/java/com/ktb/marong/dto/request/feed/PostRequestDto.java
+++ b/src/main/java/com/ktb/marong/dto/request/feed/PostRequestDto.java
@@ -15,9 +15,6 @@ public class PostRequestDto {
     @NotNull(message = "미션 ID는 필수입니다.")
     private Long missionId;
 
-    @NotBlank(message = "마니또 이름은 필수입니다.")
-    private String manittoName;
-
     @NotBlank(message = "게시글 내용은 필수입니다.")
     @Size(max = 300, message = "게시글 내용은 최대 300자까지 입력 가능합니다.")
     private String content;

--- a/src/main/java/com/ktb/marong/dto/response/manitto/ManittoInfoResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/manitto/ManittoInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.ktb.marong.dto.response.manitto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ManittoInfoResponseDto {
+    private ManittoDto manitto;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ManittoDto {
+        private String name;
+        private String profileImage;
+        private String remainingTime;  // 다음 마니또 공개까지 남은 시간 (HH:MM:SS 형식)
+    }
+}

--- a/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
@@ -1,0 +1,44 @@
+package com.ktb.marong.dto.response.manitto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MissionStatusResponseDto {
+    private ProgressDto progress;
+    private MissionsDto missions;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProgressDto {
+        private int completed;
+        private int total;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionsDto {
+        private List<MissionDto> inProgress;
+        private List<MissionDto> completed;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionDto {
+        private String title;
+        private String description;
+    }
+}

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 
     // 미션 관련 에러
     MISSION_NOT_FOUND(404, "미션을 찾을 수 없습니다."),
+    DAILY_MISSION_LIMIT_EXCEEDED(400, "하루에 한 개의 미션만 수행할 수 있습니다."),
 
     // 마니또 관련 에러 추가
     MANITTO_NOT_FOUND(404, "현재 매칭된 마니또가 없습니다."),

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -48,7 +48,11 @@ public enum ErrorCode {
     FILE_UPLOAD_ERROR(500, "파일 업로드에 실패했습니다."),
 
     // 미션 관련 에러
-    MISSION_NOT_FOUND(404, "미션을 찾을 수 없습니다.");
+    MISSION_NOT_FOUND(404, "미션을 찾을 수 없습니다."),
+
+    // 마니또 관련 에러 추가
+    MANITTO_NOT_FOUND(404, "현재 매칭된 마니또가 없습니다."),
+    MISSION_STATUS_NOT_FOUND(404, "진행 중인 미션이 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     // 미션 관련 에러
     MISSION_NOT_FOUND(404, "미션을 찾을 수 없습니다."),
     DAILY_MISSION_LIMIT_EXCEEDED(400, "하루에 한 개의 미션만 수행할 수 있습니다."),
+    MISSION_NOT_ASSIGNED(400, "할당되지 않은 미션입니다."),
 
     // 마니또 관련 에러 추가
     MANITTO_NOT_FOUND(404, "현재 매칭된 마니또가 없습니다."),

--- a/src/main/java/com/ktb/marong/repository/AnonymousNameRepository.java
+++ b/src/main/java/com/ktb/marong/repository/AnonymousNameRepository.java
@@ -6,11 +6,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AnonymousNameRepository extends JpaRepository<AnonymousName, Long> {
 
+    // 수정된 메소드: 특정 사용자의 특정 주차에 해당하는 익명 이름 조회
+    @Query("SELECT a.anonymousName FROM AnonymousName a WHERE a.user.id = :userId AND a.groupId = 1 AND a.week = :week")
+    Optional<String> findAnonymousNameByUserIdAndWeek(@Param("userId") Long userId, @Param("week") Integer week);
+
+    // 기존 메소드는 남겨두되 List로 변경
     @Query("SELECT a.anonymousName FROM AnonymousName a WHERE a.user.id = :userId AND a.groupId = 1")
-    Optional<String> findAnonymousNameByUserId(@Param("userId") Long userId);
+    List<String> findAnonymousNamesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ktb/marong/repository/ManittoRepository.java
+++ b/src/main/java/com/ktb/marong/repository/ManittoRepository.java
@@ -4,7 +4,7 @@ import com.ktb.marong.domain.manitto.Manitto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface ManittoRepository extends JpaRepository<Manitto, Long> {
@@ -12,5 +12,5 @@ public interface ManittoRepository extends JpaRepository<Manitto, Long> {
     /**
      * 특정 사용자(giver), 그룹, 주차에 해당하는 마니또 정보 조회
      */
-    Optional<Manitto> findByGiverIdAndGroupIdAndWeek(Long giverId, Long groupId, Integer week);
+    List<Manitto> findByGiverIdAndGroupIdAndWeek(Long giverId, Long groupId, Integer week);
 }

--- a/src/main/java/com/ktb/marong/repository/ManittoRepository.java
+++ b/src/main/java/com/ktb/marong/repository/ManittoRepository.java
@@ -1,0 +1,16 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.manitto.Manitto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ManittoRepository extends JpaRepository<Manitto, Long> {
+
+    /**
+     * 특정 사용자(giver), 그룹, 주차에 해당하는 마니또 정보 조회
+     */
+    Optional<Manitto> findByGiverIdAndGroupIdAndWeek(Long giverId, Long groupId, Integer week);
+}

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -1,0 +1,16 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.mission.UserMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+
+    /**
+     * 특정 사용자, 그룹, 주차에 해당하는 미션 목록 조회
+     */
+    List<UserMission> findByUserIdAndGroupIdAndWeek(Long userId, Long groupId, Integer week);
+}

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
@@ -19,4 +20,10 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
      * 특정 사용자의 특정 날짜 미션 존재 여부 확인
      */
     boolean existsByUserIdAndAssignedDate(Long userId, LocalDate assignedDate);
+
+    /**
+     * 특정 사용자, 미션, 주차에 해당하는 미션 조회
+     * 게시글 작성 시 미션 검증에 필요한 메소드
+     */
+    Optional<UserMission> findByUserIdAndMissionIdAndWeek(Long userId, Long missionId, Integer week);
 }

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -4,6 +4,7 @@ import com.ktb.marong.domain.mission.UserMission;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -13,4 +14,9 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
      * 특정 사용자, 그룹, 주차에 해당하는 미션 목록 조회
      */
     List<UserMission> findByUserIdAndGroupIdAndWeek(Long userId, Long groupId, Integer week);
+
+    /**
+     * 특정 사용자의 특정 날짜 미션 존재 여부 확인
+     */
+    boolean existsByUserIdAndAssignedDate(Long userId, LocalDate assignedDate);
 }

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -61,8 +61,11 @@ public class FeedService {
 //        String anonymousName = anonymousNameRepository.findAnonymousNameByUserId(userId)
 //                .orElseThrow(() -> new CustomException(ErrorCode.ANONYMOUS_NAME_NOT_FOUND));
 
-        // 익명 이름 조회할 때 없으면 기본값 반환
-        String anonymousName = anonymousNameRepository.findAnonymousNameByUserId(userId)
+        Manitto manitto = manittoList.get(0);
+        String manittoName = manitto.getReceiver().getNickname();  // 서버에서 manittoName 설정
+
+        // 익명 이름 조회 - 현재 주차 정보 추가
+        String anonymousName = anonymousNameRepository.findAnonymousNameByUserIdAndWeek(userId, currentWeek)
                 .orElse("익명의 " + getRandomAnimal()); // 없으면 기본 이름 생성
 
         // 이미지 업로드 처리

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -71,9 +71,11 @@ public class FeedService {
             throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED);
         }
 
-//        // 사용자의 익명 이름 조회 (MVP에서는 그룹 ID가 1로 고정) -> 익명 이름 조회 실패 시 에러코드 출력
-//        String anonymousName = anonymousNameRepository.findAnonymousNameByUserId(userId)
-//                .orElseThrow(() -> new CustomException(ErrorCode.ANONYMOUS_NAME_NOT_FOUND));
+        // 현재 사용자의 마니또 정보 조회
+        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+        if (manittoList.isEmpty()) {
+            throw new CustomException(ErrorCode.MANITTO_NOT_FOUND);
+        }
 
         Manitto manitto = manittoList.get(0);
         String manittoName = manitto.getReceiver().getNickname();  // 서버에서 manittoName 설정
@@ -98,7 +100,7 @@ public class FeedService {
                 .user(user)
                 .mission(mission)
                 .anonymousSnapshotName(anonymousName)
-                .manittoName(requestDto.getManittoName())
+                .manittoName(manittoName)
                 .content(requestDto.getContent())
                 .imageUrl(imageUrl)
                 .build();

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -1,8 +1,11 @@
 package com.ktb.marong.service.feed;
 
+import com.ktb.marong.common.util.WeekCalculator;
 import com.ktb.marong.domain.feed.Post;
 import com.ktb.marong.domain.feed.PostLike;
+import com.ktb.marong.domain.manitto.Manitto;
 import com.ktb.marong.domain.mission.Mission;
+import com.ktb.marong.domain.mission.UserMission;
 import com.ktb.marong.domain.user.User;
 import com.ktb.marong.dto.request.feed.PostLikeRequestDto;
 import com.ktb.marong.dto.request.feed.PostRequestDto;
@@ -191,7 +194,13 @@ public class FeedService {
      */
     private void updateMissionStatus(Long userId, Long missionId) {
         // UserMission 테이블에서 미션 상태를 'completed'로 업데이트
-        // MVP에서는 간소화하여 실제 구현 생략 가능
-        log.info("미션 완료 상태 업데이트: userId={}, missionId={}", userId, missionId);
+        int currentWeek = WeekCalculator.getCurrentWeek();
+
+        userMissionRepository.findByUserIdAndMissionIdAndWeek(userId, missionId, currentWeek)
+                .ifPresent(userMission -> {
+                    userMission.complete();
+                    userMissionRepository.save(userMission);
+                    log.info("미션 완료 상태 업데이트: userId={}, missionId={}", userId, missionId);
+                });
     }
 }

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -49,12 +49,11 @@ public class ManittoService {
         // 현재 주차에 해당하는 마니또 매칭 정보 조회
         int currentWeek = WeekCalculator.getCurrentWeek();
 
-        // 주차 매칭 정보가 없을 경우 기본 응답 제공 (에러 대신)
-        Manitto manitto = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek)
-                .orElse(null);
+        // findByGiverIdAndGroupIdAndWeek가 리스트를 반환하므로 첫 번째 요소를 가져옴
+        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
 
-        if (manitto == null) {
-            // 데이터가 없으면 기본 정보 반환
+        // 매칭 정보가 없을 경우 기본 응답
+        if (manittoList.isEmpty()) {
             return ManittoInfoResponseDto.builder()
                     .manitto(ManittoInfoResponseDto.ManittoDto.builder()
                             .name("아직 매칭된 마니또가 없습니다")
@@ -63,6 +62,9 @@ public class ManittoService {
                             .build())
                     .build();
         }
+
+        // 여러 매칭 중 첫 번째 매칭 정보 사용 (또는 다른 로직으로 선택)
+        Manitto manitto = manittoList.get(0);
 
         // 다음 공개까지 남은 시간 계산 (금요일 오후 5시 기준)
         String remainingTime = calculateRemainingTimeUntilReveal();

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -1,0 +1,220 @@
+package com.ktb.marong.service.manitto;
+
+import com.ktb.marong.common.util.WeekCalculator;
+import com.ktb.marong.domain.manitto.Manitto;
+import com.ktb.marong.domain.mission.Mission;
+import com.ktb.marong.domain.mission.UserMission;
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.response.manitto.ManittoInfoResponseDto;
+import com.ktb.marong.dto.response.manitto.MissionStatusResponseDto;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import com.ktb.marong.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ManittoService {
+
+    private final UserRepository userRepository;
+    private final MissionRepository missionRepository;
+    private final UserMissionRepository userMissionRepository;
+    private final ManittoRepository manittoRepository;
+    private final PostRepository postRepository;
+
+    /**
+     * 현재 마니또 정보 조회
+     * AI가 알려준 마니또 매칭 정보를 DB에서 조회
+     */
+    @Transactional(readOnly = true)
+    public ManittoInfoResponseDto getCurrentManittoInfo(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 현재 주차에 해당하는 마니또 매칭 정보 조회
+        int currentWeek = WeekCalculator.getCurrentWeek();
+        Manitto manitto = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek)
+                .orElseThrow(() -> new CustomException(ErrorCode.MANITTO_NOT_FOUND, "현재 매칭된 마니또가 없습니다."));
+
+        // 다음 공개까지 남은 시간 계산 (금요일 오후 5시 기준)
+        String remainingTime = calculateRemainingTimeUntilReveal();
+
+        return ManittoInfoResponseDto.builder()
+                .manitto(ManittoInfoResponseDto.ManittoDto.builder()
+                        .name(manitto.getReceiver().getNickname())
+                        .profileImage(manitto.getReceiver().getProfileImageUrl())
+                        .remainingTime(remainingTime)
+                        .build())
+                .build();
+    }
+
+    /**
+     * 마니또 미션 상태 조회
+     * 미션 수행 여부는 게시글 작성 여부로 판단
+     */
+    @Transactional(readOnly = true)
+    public MissionStatusResponseDto getMissionStatus(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 현재 주차에 해당하는 사용자 미션 조회
+        int currentWeek = WeekCalculator.getCurrentWeek();
+        List<UserMission> userMissions = userMissionRepository.findByUserIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+
+        // 진행 중인 미션과 완료된 미션 구분
+        List<UserMission> completedMissions = new ArrayList<>();
+        List<UserMission> inProgressMissions = new ArrayList<>();
+
+        for (UserMission userMission : userMissions) {
+            // 미션 수행 여부는 게시글 작성 여부로 판단
+            int postCount = postRepository.countByUserIdAndMissionId(userId, userMission.getMission().getId());
+
+            if (postCount > 0) {
+                completedMissions.add(userMission);
+                // 미션 상태 업데이트 (별도 트랜잭션 필요)
+                if ("ing".equals(userMission.getStatus())) {
+                    updateMissionStatus(userMission.getId());
+                }
+            } else {
+                inProgressMissions.add(userMission);
+            }
+        }
+
+        // 진행 중인 미션이 없고 완료된 미션이 있으면 새 미션 할당 (하루 1개)
+        if (inProgressMissions.isEmpty() && userMissions.size() < 5) { // 최대 5개 (일주일 중 영업일인 5일)
+            Mission newMission = getAvailableMission(userMissions);
+            if (newMission != null) {
+                UserMission userMission = assignMissionToUser(user, newMission, currentWeek);
+                inProgressMissions.add(userMission);
+            }
+        }
+
+        // DTO 변환
+        List<MissionStatusResponseDto.MissionDto> inProgressMissionDtos =
+                inProgressMissions.stream()
+                        .map(this::convertToMissionDto)
+                        .collect(Collectors.toList());
+
+        List<MissionStatusResponseDto.MissionDto> completedMissionDtos =
+                completedMissions.stream()
+                        .map(this::convertToMissionDto)
+                        .collect(Collectors.toList());
+
+        // 진행률 계산
+        int total = inProgressMissions.size() + completedMissions.size();
+        int completed = completedMissions.size();
+
+        return MissionStatusResponseDto.builder()
+                .progress(MissionStatusResponseDto.ProgressDto.builder()
+                        .completed(completed)
+                        .total(total)
+                        .build())
+                .missions(MissionStatusResponseDto.MissionsDto.builder()
+                        .inProgress(inProgressMissionDtos)
+                        .completed(completedMissionDtos)
+                        .build())
+                .build();
+    }
+
+    /**
+     * 미션 완료 상태 업데이트 (별도 트랜잭션)
+     */
+    @Transactional
+    public void updateMissionStatus(Long userMissionId) {
+        UserMission userMission = userMissionRepository.findById(userMissionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
+        userMission.complete();
+        userMissionRepository.save(userMission);
+    }
+
+    /**
+     * 사용자에게 아직 할당되지 않은 미션 찾기
+     */
+    private Mission getAvailableMission(List<UserMission> existingMissions) {
+        // 이미 할당된 미션의 ID 목록
+        List<Long> assignedMissionIds = existingMissions.stream()
+                .map(um -> um.getMission().getId())
+                .collect(Collectors.toList());
+
+        // 전체 미션 중 아직 할당되지 않은 미션 찾기
+        List<Mission> allMissions = missionRepository.findAll();
+        List<Mission> availableMissions = allMissions.stream()
+                .filter(mission -> !assignedMissionIds.contains(mission.getId()))
+                .collect(Collectors.toList());
+
+        if (availableMissions.isEmpty()) {
+            return null;
+        }
+
+        // 랜덤으로 하나 선택
+        int randomIndex = (int) (Math.random() * availableMissions.size());
+        return availableMissions.get(randomIndex);
+    }
+
+    /**
+     * 사용자에게 미션 할당
+     */
+    @Transactional
+    public UserMission assignMissionToUser(User user, Mission mission, int week) {
+        UserMission userMission = UserMission.builder()
+                .user(user)
+                .groupId(1L) // MVP에서는 기본 그룹 ID 1로 고정
+                .mission(mission)
+                .week(week)
+                .build();
+
+        return userMissionRepository.save(userMission);
+    }
+
+    /**
+     * UserMission을 MissionDto로 변환
+     */
+    private MissionStatusResponseDto.MissionDto convertToMissionDto(UserMission userMission) {
+        return MissionStatusResponseDto.MissionDto.builder()
+                .title(userMission.getMission().getTitle())
+                .description(userMission.getMission().getDescription())
+                .build();
+    }
+
+    /**
+     * 다음 마니또 공개(금요일 오후 5시)까지 남은 시간 계산
+     * 형식: HH:MM:SS
+     */
+    private String calculateRemainingTimeUntilReveal() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 이번 주 금요일 오후 5시 계산
+        LocalDateTime targetTime = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.FRIDAY))
+                .with(LocalTime.of(17, 0, 0));
+
+        // 이미 지났으면 다음 주 금요일로 설정
+        if (now.isAfter(targetTime)) {
+            targetTime = now.with(TemporalAdjusters.next(DayOfWeek.FRIDAY))
+                    .with(LocalTime.of(17, 0, 0));
+        }
+
+        // 남은 시간 계산
+        long seconds = ChronoUnit.SECONDS.between(now, targetTime);
+
+        long hours = seconds / 3600;
+        long minutes = (seconds % 3600) / 60;
+        long remainingSeconds = seconds % 60;
+
+        return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds);
+    }
+}

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -224,20 +224,20 @@ public class ManittoService {
     }
 
     /**
-     * 다음 마니또 공개(금요일 오후 5시)까지 남은 시간 계산
+     * 다음 마니또 공개(월요일 오후 12시)까지 남은 시간 계산
      * 형식: HH:MM:SS
      */
     private String calculateRemainingTimeUntilReveal() {
         LocalDateTime now = LocalDateTime.now();
 
-        // 이번 주 금요일 오후 5시 계산
-        LocalDateTime targetTime = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.FRIDAY))
-                .with(LocalTime.of(17, 0, 0));
+        // 이번 주 월요일 오후 12시 계산
+        LocalDateTime targetTime = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+                .with(LocalTime.of(12, 0, 0));
 
-        // 이미 지났으면 다음 주 금요일로 설정
+        // 이미 지났으면 다음 주 월요일로 설정
         if (now.isAfter(targetTime)) {
-            targetTime = now.with(TemporalAdjusters.next(DayOfWeek.FRIDAY))
-                    .with(LocalTime.of(17, 0, 0));
+            targetTime = now.with(TemporalAdjusters.next(DayOfWeek.MONDAY))
+                    .with(LocalTime.of(12, 0, 0));
         }
 
         // 남은 시간 계산


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 마니또 관련 API 구현
  - 마니또 정보 조회
  - 미션 상태 조회
  - 새 미션 할당


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 개발 시 고려한 사항
  - 그룹 선택 기능을 제외 후 모든 사용자가 기본 그룹(ID: 1)에 속한다고 가정
  - 마니또 정보 조회 API
    - 현재 주차(week)를 기즌으로 AI가 알려준 마니또 매칭 정보를 DB에서 직접 조회
  - 미션 상태 조회 API
    - 현재 주차에 해당하는 사용자 미션을 조회
    - 미션 수행 여부는 게시글 작성 여부로 판단
  - 새 미션 할당 API
    - 미션 할당 시 오늘 날짜에 이미 할당된 미션이 있는지 확인
    - 진행 중인 미션이 없을 경우, 아직 수행하지 않은 미션 중 하나를 할당
- 해결한 사항
  - ManittoRepository 인터페이스의 메서드가 Optional<Manitto> 형태로 단일 결과를 반환하도록 정의되어 있지만, 실제로는 여러 개의 결과가 존재하는 문제 발생 
    - List로 변경하여 여러 결과를 처리할 수 있게 함
  - AnonymousNameRepository 인터페이스의 쿼리가 특정 사용자의 익명 이름을 조회할 때 주차(week)를 고려하지 않는 문제 발생
    - 현재 주차를 고려하여 쿼리 수정
    - 특정 사용자의 특정 주차에 해당하는 익명 이름 조회
  - 게시글 작성 API에서 본인에게 해당되지 않은 미션 ID를 넣어도 작성이 가능한 문제 발생
    - FeedService의 savePost 메소드에 해당 미션이 현재 사용자에게 할당된 미션인지 확인하는 추가적인 검증 로직을 넣어 개선
    - 게시글 작성 시 사용자가 자신에게 할당된 미션만 수행할 수 있도록 검증
  - 게시글 작성 시 프론트엔드에서 마니또 이름을 넣어야 하는 로직
    - 프론트엔드에서는 missonId와 content만 제공하면 되고, manittoName은 서버 측에서 자동으로 설정하도록 수정


## 관련 이슈
- Resolved: #9 
