### PR TITLE
[Feat] MVP 1차 유지보수 (마니또, 미션, 서비스 도메인 추가 등등)

### DIFF
--- a/src/main/java/com/ktb/marong/MarongApplication.java
+++ b/src/main/java/com/ktb/marong/MarongApplication.java
@@ -2,12 +2,13 @@ package com.ktb.marong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling // 스케줄러 기능 활성화
 public class MarongApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MarongApplication.class, args);
     }
-
 }

--- a/src/main/java/com/ktb/marong/common/util/WeekCalculator.java
+++ b/src/main/java/com/ktb/marong/common/util/WeekCalculator.java
@@ -5,11 +5,11 @@ import java.time.temporal.ChronoUnit;
 
 public class WeekCalculator {
 
-    // 누적 주차수 계산하기 위한 기준 날짜 (2025년 1월 1일) (상수로 정의)
-    private static final LocalDate SERVICE_START_DATE = LocalDate.of(2025, 1, 1);
+    // 누적 주차수 계산하기 위한 기준 날짜 (2025년 1월 6일) (상수로 정의)
+    private static final LocalDate SERVICE_START_DATE = LocalDate.of(2025, 1, 6);
 
     /**
-     * 2025.01.01 기준 현재 누적 주차 계산
+     * 2025.01.06 기준 현재 누적 주차 계산
      */
     public static int getCurrentWeek() {
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173", "https://marong.app", "http://172.16.24.210:5173/auth"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173", "http://marong.co.kr", "http://www.marong.co.kr", "http://172.16.24.210:5173/auth"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "x-auth-token"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/ktb/marong/controller/FeedController.java
+++ b/src/main/java/com/ktb/marong/controller/FeedController.java
@@ -82,7 +82,7 @@ public class FeedController {
 
         log.info("피드 조회 요청: userId={}, page={}, pageSize={}", userId, page, pageSize);
 
-        PostPageResponseDto response = feedService.getPosts(page, pageSize);
+        PostPageResponseDto response = feedService.getPosts(userId, page, pageSize);
 
         return ResponseEntity.ok(ApiResponse.success(
                 response,

--- a/src/main/java/com/ktb/marong/domain/feed/Post.java
+++ b/src/main/java/com/ktb/marong/domain/feed/Post.java
@@ -34,6 +34,10 @@ public class Post {
     @Column(name = "group_id", nullable = false)
     private Long groupId = 1L; // 기본 그룹 ID는 1로 고정
 
+    // 주차 정보 필드 추가
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id", nullable = false)
     private Mission mission;
@@ -62,13 +66,18 @@ public class Post {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Post(User user, Mission mission, String anonymousSnapshotName,
+    public Post(User user, Mission mission, Integer week, String anonymousSnapshotName,
                 String manittoName, String content, String imageUrl) {
         this.user = user;
         this.mission = mission;
+        this.week = week;
         this.anonymousSnapshotName = anonymousSnapshotName;
         this.manittoName = manittoName;
         this.content = content;
         this.imageUrl = imageUrl;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 }

--- a/src/main/java/com/ktb/marong/domain/manitto/Manitto.java
+++ b/src/main/java/com/ktb/marong/domain/manitto/Manitto.java
@@ -21,21 +21,21 @@ public class Manitto {
     private Long groupId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "giver_id", nullable = false)
-    private User giver;  // 마니띠 (현재 사용자)
+    @JoinColumn(name = "manittee_id", nullable = false) // giver_id에서 변경
+    private User manittee;  // 현재 사용자
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "receiver_id", nullable = false)
-    private User receiver;  // 마니또 (대상 사용자)
+    @JoinColumn(name = "manitto_id", nullable = false) // receiver_id에서 변경
+    private User manitto;  // 대상 사용자
 
     @Column(name = "week", nullable = false)
     private Integer week;
 
     @Builder
-    public Manitto(Long groupId, User giver, User receiver, Integer week) {
+    public Manitto(Long groupId, User manittee, User manitto, Integer week) {
         this.groupId = groupId;
-        this.giver = giver;
-        this.receiver = receiver;
+        this.manittee = manittee;
+        this.manitto = manitto;
         this.week = week;
     }
 }

--- a/src/main/java/com/ktb/marong/domain/mission/UserMission.java
+++ b/src/main/java/com/ktb/marong/domain/mission/UserMission.java
@@ -65,4 +65,26 @@ public class UserMission {
     public void complete() {
         this.status = "completed";
     }
+
+    /**
+     * 미션 미완료 처리
+     * 하루가 지났지만 완료하지 못한 미션에 대한 상태 갱신
+     */
+    public void markAsIncomplete() {
+        this.status = "incomplete";
+    }
+
+    /**
+     * 미션이 진행 중인지 확인
+     */
+    public boolean isInProgress() {
+        return "ing".equals(this.status);
+    }
+
+    /**
+     * 미션이 완료되었는지 확인
+     */
+    public boolean isCompleted() {
+        return "completed".equals(this.status);
+    }
 }

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
@@ -22,6 +22,7 @@ public class PostResponseDto {
     private int likes;
     private LocalDateTime createdAt;
     private String imageUrl;
+    private Integer week; // 주차 정보 추가
 
     @JsonProperty("isLiked") // 필드명을 isLiked로 명시적 지정
     private boolean isLiked; // 현재 사용자가 좋아요 눌렀는지 여부
@@ -36,6 +37,7 @@ public class PostResponseDto {
                 .likes(likesCount)
                 .createdAt(post.getCreatedAt())
                 .imageUrl(post.getImageUrl())
+                .week(post.getWeek()) // 주차 정보 포함
                 .isLiked(isLiked)
                 .build();
     }

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.ktb.marong.dto.response.feed;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ktb.marong.domain.feed.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +23,10 @@ public class PostResponseDto {
     private LocalDateTime createdAt;
     private String imageUrl;
 
-    public static PostResponseDto fromEntity(Post post, int likesCount) {
+    @JsonProperty("isLiked") // 필드명을 isLiked로 명시적 지정
+    private boolean isLiked; // 현재 사용자가 좋아요 눌렀는지 여부
+
+    public static PostResponseDto fromEntity(Post post, int likesCount, boolean isLiked) {
         return PostResponseDto.builder()
                 .feedId(post.getId())
                 .author(post.getAnonymousSnapshotName())
@@ -32,6 +36,7 @@ public class PostResponseDto {
                 .likes(likesCount)
                 .createdAt(post.getCreatedAt())
                 .imageUrl(post.getImageUrl())
+                .isLiked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.ktb.marong.dto.response.feed;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ktb.marong.domain.feed.Post;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,9 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+        getterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.NONE)
 public class PostResponseDto {
     private Long feedId;
     private String author;
@@ -24,8 +28,8 @@ public class PostResponseDto {
     private String imageUrl;
     private Integer week; // 주차 정보 추가
 
-    @JsonProperty("isLiked") // 필드명을 isLiked로 명시적 지정
-    private boolean isLiked; // 현재 사용자가 좋아요 눌렀는지 여부
+    @JsonProperty("isLiked")
+    private boolean liked; // 필드명 변경: isLiked -> liked
 
     public static PostResponseDto fromEntity(Post post, int likesCount, boolean isLiked) {
         return PostResponseDto.builder()
@@ -38,7 +42,7 @@ public class PostResponseDto {
                 .createdAt(post.getCreatedAt())
                 .imageUrl(post.getImageUrl())
                 .week(post.getWeek()) // 주차 정보 포함
-                .isLiked(isLiked)
+                .liked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
@@ -40,5 +40,6 @@ public class MissionStatusResponseDto {
     public static class MissionDto {
         private String title;
         private String description;
+        private String difficulty;
     }
 }

--- a/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
@@ -38,6 +38,7 @@ public class MissionStatusResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MissionDto {
+        private Long missionId;
         private String title;
         private String description;
         private String difficulty;

--- a/src/main/java/com/ktb/marong/repository/ManittoRepository.java
+++ b/src/main/java/com/ktb/marong/repository/ManittoRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ManittoRepository extends JpaRepository<Manitto, Long> {
 
     /**
-     * 특정 사용자(giver), 그룹, 주차에 해당하는 마니또 정보 조회
+     * 특정 사용자(manittee), 그룹, 주차에 해당하는 마니또 정보 조회
      */
-    List<Manitto> findByGiverIdAndGroupIdAndWeek(Long giverId, Long groupId, Integer week);
+    List<Manitto> findByManitteeIdAndGroupIdAndWeek(Long manitteeId, Long groupId, Integer week);
 }

--- a/src/main/java/com/ktb/marong/repository/PostRepository.java
+++ b/src/main/java/com/ktb/marong/repository/PostRepository.java
@@ -8,23 +8,34 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // MVP에서는 모든 게시글을 최신순으로 가져옴 (그룹 필터링 없음)
+    // 기존 메서드 유지 (필요시 사용) -> MVP에서는 모든 게시글을 최신순으로 가져옴 (그룹 필터링 없음)
     @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    // 특정 사용자, 특정 미션에 대한 게시글 수 조회
+    // 주차별 게시글 조회 메서드 추가
+    @Query("SELECT p FROM Post p WHERE p.week = :week ORDER BY p.createdAt DESC")
+    Page<Post> findAllByWeekOrderByCreatedAtDesc(@Param("week") Integer week, Pageable pageable);
+
+    // 특정 사용자, 특정 미션에 대한 게시글 수 조회 (기존 메서드)
     @Query("SELECT COUNT(p) FROM Post p WHERE p.user.id = :userId AND p.mission.id = :missionId")
     int countByUserIdAndMissionId(@Param("userId") Long userId, @Param("missionId") Long missionId);
 
-    // 특정 사용자, 특정 미션, 특정 주차에 대한 게시글 수 조회 (추가된 메서드)
-    @Query("SELECT COUNT(p) FROM Post p JOIN p.mission m " +
-            "JOIN UserMission um ON m.id = um.mission.id " +
-            "WHERE p.user.id = :userId AND m.id = :missionId AND um.week = :week")
+    // 특정 사용자, 특정 미션, 특정 주차에 대한 게시글 수 조회 (수정된 메서드)
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.user.id = :userId AND p.mission.id = :missionId AND p.week = :week")
     int countByUserIdAndMissionIdAndWeek(
             @Param("userId") Long userId,
             @Param("missionId") Long missionId,
             @Param("week") Integer week);
+
+    // 특정 날짜 범위의 게시글을 주차별로 업데이트하기 위한 메서드
+    @Query("SELECT p FROM Post p WHERE p.createdAt BETWEEN :startDate AND :endDate")
+    List<Post> findByCreatedAtBetween(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/ktb/marong/repository/PostRepository.java
+++ b/src/main/java/com/ktb/marong/repository/PostRepository.java
@@ -15,6 +15,16 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
+    // 특정 사용자, 특정 미션에 대한 게시글 수 조회
     @Query("SELECT COUNT(p) FROM Post p WHERE p.user.id = :userId AND p.mission.id = :missionId")
     int countByUserIdAndMissionId(@Param("userId") Long userId, @Param("missionId") Long missionId);
+
+    // 특정 사용자, 특정 미션, 특정 주차에 대한 게시글 수 조회 (추가된 메서드)
+    @Query("SELECT COUNT(p) FROM Post p JOIN p.mission m " +
+            "JOIN UserMission um ON m.id = um.mission.id " +
+            "WHERE p.user.id = :userId AND m.id = :missionId AND um.week = :week")
+    int countByUserIdAndMissionIdAndWeek(
+            @Param("userId") Long userId,
+            @Param("missionId") Long missionId,
+            @Param("week") Integer week);
 }

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -25,7 +25,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
 
     /**
      * 특정 사용자, 미션, 주차에 해당하는 미션 조회
-     * 게시글 작성 시 미션 검증에 필요한 메소드
+     * 게시글 작성 시 미션 검증 및 완료 여부 확인용
      */
     Optional<UserMission> findByUserIdAndMissionIdAndWeek(Long userId, Long missionId, Integer week);
 
@@ -41,4 +41,10 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
      * 주로 이전 주차의 진행 중인 미션을 모두 찾아 미완료 처리하기 위해 사용
      */
     List<UserMission> findByStatusAndWeek(String status, Integer week);
+
+    /**
+     * 특정 주차의 모든 미션 조회
+     * 주차 변경 시 남아있는 미션을 초기화하기 위해 사용
+     */
+    List<UserMission> findByWeek(Integer week);
 }

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -35,4 +35,10 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
      */
     @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate < :date AND um.status = 'ing'")
     List<UserMission> findIncompleteMissionsBeforeDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+
+    /**
+     * 특정 상태와 주차에 해당하는 모든 미션 조회
+     * 주로 이전 주차의 진행 중인 미션을 모두 찾아 미완료 처리하기 위해 사용
+     */
+    List<UserMission> findByStatusAndWeek(String status, Integer week);
 }

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -2,6 +2,8 @@ package com.ktb.marong.repository;
 
 import com.ktb.marong.domain.mission.UserMission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -26,4 +28,11 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
      * 게시글 작성 시 미션 검증에 필요한 메소드
      */
     Optional<UserMission> findByUserIdAndMissionIdAndWeek(Long userId, Long missionId, Integer week);
+
+    /**
+     * 특정 날짜 이전에 할당된 진행 중인 미션을 찾는 쿼리
+     * 완료되지 않고 지나간 미션들을 처리하기 위함
+     */
+    @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate < :date AND um.status = 'ing'")
+    List<UserMission> findIncompleteMissionsBeforeDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -45,7 +46,7 @@ public class FeedService {
     private final FileUploadService fileUploadService;
 
     /**
-     * 게시글 업로드
+     * 게시글 업로드 - 주차 정보 추가
      */
     @Transactional
     public Long savePost(Long userId, PostRequestDto requestDto, MultipartFile image) {
@@ -69,19 +70,23 @@ public class FeedService {
             throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED, "이미 완료된 미션입니다.");
         }
 
-        // 해당 미션을 이미 수행했는지 확인
-        if (postRepository.countByUserIdAndMissionId(userId, requestDto.getMissionId()) > 0) {
-            throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED);
+        // 해당 미션을 현재 주차에 이미 수행했는지 확인 - week 포함하여 체크
+        int postCount = postRepository.countByUserIdAndMissionIdAndWeek(userId, requestDto.getMissionId(), currentWeek);
+        log.info("미션 수행 확인: userId={}, missionId={}, week={}, postCount={}",
+                userId, requestDto.getMissionId(), currentWeek, postCount);
+
+        if (postCount > 0) {
+            throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED, "이번 주차에 이미 해당 미션을 완료했습니다.");
         }
 
-        // 현재 사용자의 마니또 정보 조회 - 메서드 이름 변경
+        // 현재 사용자의 마니또 정보 조회
         List<Manitto> manittoList = manittoRepository.findByManitteeIdAndGroupIdAndWeek(userId, 1L, currentWeek);
         if (manittoList.isEmpty()) {
             throw new CustomException(ErrorCode.MANITTO_NOT_FOUND);
         }
 
         Manitto manitto = manittoList.get(0);
-        String manittoName = manitto.getManitto().getNickname();  // 필드 이름 변경: receiver -> manitto // 서버에서 ManittoName 설정
+        String manittoName = manitto.getManitto().getNickname(); // 필드 이름 변경: receiver -> manitto // 서버에서 ManittoName 설정
 
         // 익명 이름 조회 - 현재 주차 정보 추가
         String anonymousName = anonymousNameRepository.findAnonymousNameByUserIdAndWeek(userId, currentWeek)
@@ -98,10 +103,11 @@ public class FeedService {
             }
         }
 
-        // 게시글 생성
+        // 게시글 생성 - 주차 정보 포함
         Post post = Post.builder()
                 .user(user)
                 .mission(mission)
+                .week(currentWeek) // 주차 정보 추가
                 .anonymousSnapshotName(anonymousName)
                 .manittoName(manittoName)
                 .content(requestDto.getContent())
@@ -112,7 +118,7 @@ public class FeedService {
         Post savedPost = postRepository.save(post);
 
         // 미션 완료 상태 업데이트 (UserMission 테이블)
-        updateMissionStatus(userId, mission.getId());
+        updateMissionStatus(userId, mission.getId(), currentWeek);
 
         return savedPost.getId();
     }
@@ -167,12 +173,14 @@ public class FeedService {
     }
 
     /**
-     * 게시글 목록 조회 (MVP에서는 그룹 필터링 없이 모든 게시글 조회)
+     * 게시글 목록 조회 (MVP에서는 그룹 필터링 없이 모든 게시글 최신순으로 조회)
      * 현재 사용자의 좋아요 여부를 함께 반환
      */
     @Transactional(readOnly = true)
     public PostPageResponseDto getPosts(Long userId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize);
+
+        // 주차 필터링 없이 모든 게시글을 최신순으로 조회
         Page<Post> postPage = postRepository.findAllByOrderByCreatedAtDesc(pageable);
 
         List<PostResponseDto> postDtos = postPage.getContent().stream()
@@ -194,17 +202,52 @@ public class FeedService {
     }
 
     /**
-     * 미션 완료 상태 업데이트
+     * 미션 완료 상태 업데이트 - 주차 정보 포함
      */
-    private void updateMissionStatus(Long userId, Long missionId) {
+    private void updateMissionStatus(Long userId, Long missionId, Integer week) {
         // UserMission 테이블에서 미션 상태를 'completed'로 업데이트
-        int currentWeek = WeekCalculator.getCurrentWeek();
-
-        userMissionRepository.findByUserIdAndMissionIdAndWeek(userId, missionId, currentWeek)
+        userMissionRepository.findByUserIdAndMissionIdAndWeek(userId, missionId, week)
                 .ifPresent(userMission -> {
                     userMission.complete();
                     userMissionRepository.save(userMission);
-                    log.info("미션 완료 상태 업데이트: userId={}, missionId={}", userId, missionId);
+                    log.info("미션 완료 상태 업데이트: userId={}, missionId={}, week={}", userId, missionId, week);
                 });
+    }
+
+    /**
+     * 주차 정보 마이그레이션 - 기존 게시글에 주차 정보 추가
+     */
+    @Transactional
+    public void migratePostWeekData() {
+        // 기존 데이터에 대해 게시글 생성일자를 기준으로 주차 계산
+        List<Post> allPosts = postRepository.findAll();
+
+        for (Post post : allPosts) {
+            // 게시글 생성일자를 기준으로 주차 계산
+            LocalDateTime createdAt = post.getCreatedAt();
+            int week = WeekCalculator.getWeekOf(createdAt.toLocalDate());
+
+            // 주차 정보가 없거나 0인 경우에만 업데이트
+            if (post.getWeek() == null || post.getWeek() == 0) {
+                // 엔티티를 직접 수정할 수 없으므로 새 엔티티 생성 후 저장
+                Post updatedPost = Post.builder()
+                        .user(post.getUser())
+                        .mission(post.getMission())
+                        .week(week)
+                        .anonymousSnapshotName(post.getAnonymousSnapshotName())
+                        .manittoName(post.getManittoName())
+                        .content(post.getContent())
+                        .imageUrl(post.getImageUrl())
+                        .build();
+
+                // ID 설정 (기존 ID 유지)
+                updatedPost.setId(post.getId());
+
+                // 저장
+                postRepository.save(updatedPost);
+
+                log.info("게시글 주차 정보 마이그레이션: postId={}, week={}", post.getId(), week);
+            }
+        }
     }
 }

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -74,14 +74,14 @@ public class FeedService {
             throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED);
         }
 
-        // 현재 사용자의 마니또 정보 조회
-        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+        // 현재 사용자의 마니또 정보 조회 - 메서드 이름 변경
+        List<Manitto> manittoList = manittoRepository.findByManitteeIdAndGroupIdAndWeek(userId, 1L, currentWeek);
         if (manittoList.isEmpty()) {
             throw new CustomException(ErrorCode.MANITTO_NOT_FOUND);
         }
 
         Manitto manitto = manittoList.get(0);
-        String manittoName = manitto.getReceiver().getNickname();  // 서버에서 manittoName 설정
+        String manittoName = manitto.getManitto().getNickname();  // 필드 이름 변경: receiver -> manitto // 서버에서 ManittoName 설정
 
         // 익명 이름 조회 - 현재 주차 정보 추가
         String anonymousName = anonymousNameRepository.findAnonymousNameByUserIdAndWeek(userId, currentWeek)

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -151,6 +151,14 @@ public class ManittoService {
         int currentWeek = WeekCalculator.getCurrentWeek();
         LocalDate today = LocalDate.now();
 
+        // 현재 주차에 해당하는 마니또 매칭 정보 조회 (그룹 ID 1 고정)
+        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+
+        // 마니또 매칭 정보가 없는 경우 예외 발생
+        if (manittoList.isEmpty()) {
+            throw new CustomException(ErrorCode.MANITTO_NOT_FOUND, "마니또 매칭 정보가 없어 미션을 할당할 수 없습니다.");
+        }
+
         // 오늘 이미 할당된 미션이 있는지 확인
         boolean hasTodayMission = userMissionRepository.existsByUserIdAndAssignedDate(userId, today);
         if (hasTodayMission) {

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -49,8 +49,8 @@ public class ManittoService {
         // 현재 주차에 해당하는 마니또 매칭 정보 조회
         int currentWeek = WeekCalculator.getCurrentWeek();
 
-        // findByGiverIdAndGroupIdAndWeek가 리스트를 반환하므로 첫 번째 요소를 가져옴
-        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+        // findByGiverIdAndGroupIdAndWeek를 findByManitteeIdAndGroupIdAndWeek로 변경
+        List<Manitto> manittoList = manittoRepository.findByManitteeIdAndGroupIdAndWeek(userId, 1L, currentWeek);
 
         // 매칭 정보가 없을 경우 기본 응답
         if (manittoList.isEmpty()) {
@@ -63,7 +63,7 @@ public class ManittoService {
                     .build();
         }
 
-        // 여러 매칭 중 첫 번째 매칭 정보 사용 (또는 다른 로직으로 선택)
+        // 여러 매칭 중 첫 번째 매칭 정보 사용
         Manitto manitto = manittoList.get(0);
 
         // 다음 공개까지 남은 시간 계산 (금요일 오후 5시 기준)
@@ -71,8 +71,8 @@ public class ManittoService {
 
         return ManittoInfoResponseDto.builder()
                 .manitto(ManittoInfoResponseDto.ManittoDto.builder()
-                        .name(manitto.getReceiver().getNickname())
-                        .profileImage(manitto.getReceiver().getProfileImageUrl())
+                        .name(manitto.getManitto().getNickname()) // receiver에서 manitto로 변경
+                        .profileImage(manitto.getManitto().getProfileImageUrl()) // receiver에서 manitto로 변경
                         .remainingTime(remainingTime)
                         .build())
                 .build();
@@ -152,9 +152,10 @@ public class ManittoService {
         LocalDate today = LocalDate.now();
 
         // 현재 주차에 해당하는 마니또 매칭 정보 조회 (그룹 ID 1 고정)
-        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+        // findByGiverIdAndGroupIdAndWeek를 findByManitteeIdAndGroupIdAndWeek로 변경
+        List<Manitto> manittoList = manittoRepository.findByManitteeIdAndGroupIdAndWeek(userId, 1L, currentWeek);
 
-        // 마니또 매칭 정보가 없는 경우 예외 발생
+        // 마니또 매칭 정보가 없는 경우 예외 발생 (추가된 부분)
         if (manittoList.isEmpty()) {
             throw new CustomException(ErrorCode.MANITTO_NOT_FOUND, "마니또 매칭 정보가 없어 미션을 할당할 수 없습니다.");
         }

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -220,6 +220,7 @@ public class ManittoService {
         return MissionStatusResponseDto.MissionDto.builder()
                 .title(userMission.getMission().getTitle())
                 .description(userMission.getMission().getDescription())
+                .difficulty(userMission.getMission().getDifficulty())
                 .build();
     }
 

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -226,6 +226,7 @@ public class ManittoService {
      */
     private MissionStatusResponseDto.MissionDto convertToMissionDto(UserMission userMission) {
         return MissionStatusResponseDto.MissionDto.builder()
+                .missionId(userMission.getMission().getId()) // 미션 ID 추가
                 .title(userMission.getMission().getTitle())
                 .description(userMission.getMission().getDescription())
                 .difficulty(userMission.getMission().getDifficulty())

--- a/src/main/java/com/ktb/marong/service/recommendation/PlaceRecommendationService.java
+++ b/src/main/java/com/ktb/marong/service/recommendation/PlaceRecommendationService.java
@@ -43,7 +43,8 @@ public class PlaceRecommendationService {
 
         // 현재 주차에 해당하는 마니또 매칭 정보 조회 (그룹 ID 1 고정)
         int currentWeek = WeekCalculator.getCurrentWeek();
-        List<Manitto> manittoList = manittoRepository.findByGiverIdAndGroupIdAndWeek(userId, 1L, currentWeek);
+        // findByGiverIdAndGroupIdAndWeek를 findByManitteeIdAndGroupIdAndWeek로 변경
+        List<Manitto> manittoList = manittoRepository.findByManitteeIdAndGroupIdAndWeek(userId, 1L, currentWeek);
 
         // 마니또 매칭이 없는 경우 예외 발생
         if (manittoList.isEmpty()) {


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 미션 정보 조회 시 난이도 필드 조회 추가
- 마니또 매칭 정보 존재 여부 확인 후 미션 할당
- 누적 주차수 계산 기준일 변경
- 현재 사용자 게시글 좋아요 여부 표시 필드 추가
- 미션 상태 응답에 미션 ID도 함께 조회되도록 구현
- Manitto 테이블의 giver_id와 receiver_id를 각각 manittee_id와 manitto_id로 변경
- 진행 중인 미션을 완료하지 않고 하루가 지나면 해당 미션 자동으로 미완료(incomplete) 상태로 변경
- 마니또 주기 바뀔 때 이전 마니또 주기의 미션 정보 자동 초기화
- Origin에 서비스 도메인 추가
- 주차가 지날 때마다 미션 정보 초기화 처리
- 현재 사용자 좋아요 여부 표시할 때 liked와 isLiked 필드 2개가 표시되는 문제 해결 -> isLiked만 출력되도록 수정


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
추후 추가 예정



## 관련 이슈
- Resolved: #
