### PR TITLE
[Feat] MVP 3차 유지보수

### DIFF
--- a/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/manitto/MissionStatusResponseDto.java
@@ -21,6 +21,7 @@ public class MissionStatusResponseDto {
     @AllArgsConstructor
     public static class ProgressDto {
         private int completed;
+        private int incomplete; // 추가된 미완료 미션 개수 필드
         private int total;
     }
 
@@ -31,6 +32,7 @@ public class MissionStatusResponseDto {
     public static class MissionsDto {
         private List<MissionDto> inProgress;
         private List<MissionDto> completed;
+        private List<MissionDto> incomplete;
     }
 
     @Getter

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -30,11 +30,23 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
     Optional<UserMission> findByUserIdAndMissionIdAndWeek(Long userId, Long missionId, Integer week);
 
     /**
-     * 특정 날짜 이전에 할당된 진행 중인 미션을 찾는 쿼리
+     * 특정 주차의 특정 날짜 이전에 할당된 진행 중인 미션을 찾는 쿼리
      * 완료되지 않고 지나간 미션들을 처리하기 위함
      */
-    @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate < :date AND um.status = 'ing'")
-    List<UserMission> findIncompleteMissionsBeforeDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+    @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate < :date AND um.status = 'ing' AND um.week = :week")
+    List<UserMission> findIncompleteMissionsBeforeDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("week") Integer week);
+
+    /**
+     * 특정 주차의 오늘 할당된 미션 조회
+     */
+    @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate = :date AND um.status = 'ing' AND um.week = :week")
+    List<UserMission> findTodaysMissions(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("week") Integer week);
 
     /**
      * 특정 상태와 주차에 해당하는 모든 미션 조회

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -40,10 +40,19 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
             @Param("week") Integer week);
 
     /**
-     * 특정 주차의 오늘 할당된 미션 조회
+     * 특정 주차의 오늘 할당된 진행 중인 미션 조회
      */
     @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate = :date AND um.status = 'ing' AND um.week = :week")
     List<UserMission> findTodaysMissions(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("week") Integer week);
+
+    /**
+     * 특정 날짜와 주차에 할당된 모든 미션 조회 (상태 무관)
+     */
+    @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.assignedDate = :date AND um.week = :week")
+    List<UserMission> findAllMissionsAssignedOnDate(
             @Param("userId") Long userId,
             @Param("date") LocalDate date,
             @Param("week") Integer week);

--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -195,8 +195,8 @@ public class ManittoService {
         // 현재 주차의 이전 미션들을 미완료 상태로 변경
         handleExpiredMissions(userId, today, currentWeek);
 
-        // 오늘 이미 할당된 미션이 있는지 확인
-        List<UserMission> todaysMissions = userMissionRepository.findTodaysMissions(userId, today, currentWeek);
+        // 오늘 이미 할당된 미션이 있는지 확인 (상태와 관계없이)
+        List<UserMission> todaysMissions = userMissionRepository.findAllMissionsAssignedOnDate(userId, today, currentWeek);
         if (!todaysMissions.isEmpty()) {
             throw new CustomException(ErrorCode.DAILY_MISSION_LIMIT_EXCEEDED, "하루에 한 개의 미션만 수행할 수 있습니다.");
         }


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 미션 상태 조회시 미완료된 미션 개수도 표시
- 주차별 미션 상태 정보 관련 수정
  - 주차가 지나면 미션 데이터 초기화 후 새로 시작
  - 미션을 완료하지 않고 하루가 지나면 미션 미완료 상태로 변경
- 미션 상태 관계 없이 하루에 하나의 미션만 할당 받을 수 있도록 수정
  - 미션 할당 시 주차, 할당된 날짜 모두 고려하여 조회하고 할당하도록 수정



## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
추후 추가 예정



## 관련 이슈
- Resolved: #
