### PR TITLE
[Feat] MVP 5차 유지보수

### DIFF
--- a/src/main/java/com/ktb/marong/dto/response/manitto/ManittoInfoResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/manitto/ManittoInfoResponseDto.java
@@ -10,7 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ManittoInfoResponseDto {
-    private ManitteeDto manittee;
+    private String role; // "manitto", "manittee" (매칭이 있는 경우만)
+    private ManitteeDto manittee; // 마니또인 경우에만 존재
+    private ManittoDto manitto; // 마니띠인 경우에만 존재
 
     @Getter
     @Builder
@@ -20,5 +22,14 @@ public class ManittoInfoResponseDto {
         private String name;
         private String profileImage;
         private String remainingTime;  // 다음 마니또 공개까지 남은 시간 (HH:MM:SS 형식)
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ManittoDto {
+        private String anonymousName; // 마니또가 사용하는 익명 이름
+        private String remainingTime; // 다음 마니또 공개까지 남은 시간 (HH:MM:SS 형식)
     }
 }

--- a/src/main/java/com/ktb/marong/repository/ManittoRepository.java
+++ b/src/main/java/com/ktb/marong/repository/ManittoRepository.java
@@ -11,6 +11,13 @@ public interface ManittoRepository extends JpaRepository<Manitto, Long> {
 
     /**
      * 특정 사용자(manitto), 그룹, 주차에 해당하는 마니또 정보 조회
+     * 해당 사용자가 마니또 역할을 하는 매칭 정보
      */
     List<Manitto> findByManittoIdAndGroupIdAndWeek(Long manittoId, Long groupId, Integer week);
+
+    /**
+     * 특정 사용자(manittee), 그룹, 주차에 해당하는 마니또 정보 조회
+     * 해당 사용자가 마니띠 역할을 하는 매칭 정보
+     */
+    List<Manitto> findByManitteeIdAndGroupIdAndWeek(Long manitteeId, Long groupId, Integer week);
 }


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 마니또 정보 조회 API 수정
  - 사용자의 역할(마니또, 마니띠) 구분하여 조회되도록 수정
  - 마니띠 역할의 사용자에게는 마니또의 익명 이름도 조회되도록 구현
  - 매칭이 안된 사용자는 기존 응답 그대로 출력


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
추후 추가 예정 



## 관련 이슈
- Resolved: #
