### PR TITLE
[Feat] ver2 - 게시글 닉네임 관련 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -49,6 +50,8 @@ dependencies {
 
 	// AWS S3 의존성 추가
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ktb/marong/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/marong/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/survey").authenticated()
                         .requestMatchers("/groups/**").authenticated()
+                        .requestMatchers("/test-discord").permitAll()
                         // 인증이 필요한 API
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
@@ -45,4 +45,19 @@ public class PostResponseDto {
                 .liked(isLiked)
                 .build();
     }
+
+    public static PostResponseDto fromEntityWithRealTimeManitteeName(Post post, int likesCount, boolean isLiked, String realTimeManitteeName) {
+        return PostResponseDto.builder()
+                .feedId(post.getId())
+                .author(post.getAnonymousSnapshotName())
+                .missionTitle(post.getMission().getTitle())
+                .manitteeName(realTimeManitteeName) // 실시간으로 결정된 마니띠 이름 사용
+                .content(post.getContent())
+                .likes(likesCount)
+                .createdAt(post.getCreatedAt())
+                .imageUrl(post.getImageUrl())
+                .week(post.getWeek())
+                .liked(isLiked)
+                .build();
+    }
 }

--- a/src/main/resources/DiscordTestController.java
+++ b/src/main/resources/DiscordTestController.java
@@ -1,0 +1,17 @@
+package com.ktb.marong.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController("/api/test-discord")
+public class DiscordTestController {
+    private static final Logger log = LoggerFactory.getLogger(DiscordTestController.class);
+
+    @GetMapping
+    public ResponseEntity<String> testDiscordWebhook() {
+        log.error(">> TEST: Discord webhook 연동 확인용 에러 메시지");
+        return ResponseEntity.ok("Discord webhook test triggered");
+    }
+}

--- a/src/main/resources/discord-error-appender.xml
+++ b/src/main/resources/discord-error-appender.xml
@@ -1,0 +1,22 @@
+<included>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>${DISCORD_ERROR_WEBHOOK_URL}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>
+
+                \n [ERROR LOG] ============================================================================
+                \n %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%logger{2}.%M:%L] - %msg%n
+                %ex{full}%n
+            </pattern>
+        </layout>
+        <username>백엔드에러봇🚨 </username>
+        <tts>false</tts>
+    </appender>
+
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD" />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,18 @@
+<configuration>
+    <include resource="console-appender.xml"/>
+    <include resource="discord-error-appender.xml"/>
+    <appender-ref ref="ASYNC_DISCORD" />
+
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <!-- 로깅 테마 -->
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <springProperty name="DISCORD_ERROR_WEBHOOK_URL" source="logging.discord.webhook-url"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ASYNC_DISCORD" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 게시글 조회 시에 작성자 이름을 그룹 내 닉네임으로 조회되도록 수정
- 백엔드 에러로그 디스코드 웹훅 관련 설정


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 게시글 작성 뿐만 아니라 게시글 조회 시에 마니띠 이름이 그룹 내 닉네임으로 보이도록 수정. 기존에는 게시글 작성 시에만 그룹 닉네임 사용하도록 함.
- 백엔드 에러로그 디스코드 웹훅 관련 설정하기 위한 파일 수정 및 파일 추가



## 관련 이슈
- Resolved: #
