### PR TITLE
[Feat] ver2 - 그룹 관련 기능 및 게시글 조회 기능 보완

### DIFF
--- a/src/main/java/com/ktb/marong/common/util/GroupValidator.java
+++ b/src/main/java/com/ktb/marong/common/util/GroupValidator.java
@@ -43,9 +43,20 @@ public class GroupValidator {
     }
 
     /**
-     * 그룹 이름 정규화 (앞뒤 공백 제거, 연속 공백 하나로 압축)
+     * 그룹 이름 정규화 - 중복체크용 (모든 공백 제거 후 소문자 변환)
      */
     public static String normalizeGroupName(String groupName) {
+        if (groupName == null) {
+            return null;
+        }
+        // 모든 공백 제거 후 소문자로 변환하여 중복 체크용 문자열 생성
+        return groupName.trim().replaceAll("\\s+", "").toLowerCase();
+    }
+
+    /**
+     * 그룹 이름 정규화 - 표시용 (앞뒤 공백 제거, 연속 공백 하나로 압축)
+     */
+    public static String normalizeGroupNameForDisplay(String groupName) {
         if (groupName == null) {
             return null;
         }

--- a/src/main/java/com/ktb/marong/controller/GroupController.java
+++ b/src/main/java/com/ktb/marong/controller/GroupController.java
@@ -188,6 +188,13 @@ public class GroupController {
         log.info("닉네임 중복 체크 요청: userId={}, groupId={}, nickname={}", userId, groupId, nickname);
 
         try {
+            // 먼저 그룹 존재 여부 확인
+            if (!groupRepository.existsById(groupId)) {
+                log.warn("존재하지 않는 그룹: groupId={}", groupId);
+                return ResponseEntity.badRequest()
+                        .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+            }
+
             // 닉네임 형식 검증
             GroupNicknameValidator.validateNicknameFormat(nickname);
             String normalizedNickname = GroupNicknameValidator.normalizeNickname(nickname);
@@ -238,6 +245,13 @@ public class GroupController {
         log.info("그룹 내 사용 중인 닉네임 목록 조회: userId={}, groupId={}", userId, groupId);
 
         try {
+            // 먼저 그룹 존재 여부 확인
+            if (!groupRepository.existsById(groupId)) {
+                log.warn("존재하지 않는 그룹: groupId={}", groupId);
+                return ResponseEntity.badRequest()
+                        .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+            }
+
             List<String> usedNicknames = groupService.getUsedNicknames(groupId);
 
             Map<String, Object> response = new HashMap<>();
@@ -268,6 +282,13 @@ public class GroupController {
         log.info("그룹 내 닉네임 설정 여부 확인 요청: userId={}, groupId={}", userId, groupId);
 
         try {
+            // 먼저 그룹 존재 여부 확인
+            if (!groupRepository.existsById(groupId)) {
+                log.warn("존재하지 않는 그룹: groupId={}", groupId);
+                return ResponseEntity.badRequest()
+                        .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+            }
+
             boolean hasNickname = groupService.hasGroupNickname(userId, groupId);
 
             Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/ktb/marong/controller/GroupController.java
+++ b/src/main/java/com/ktb/marong/controller/GroupController.java
@@ -154,7 +154,7 @@ public class GroupController {
             GroupValidator.validateGroupName(groupName);
             String normalizedName = GroupValidator.normalizeGroupName(groupName);
 
-            boolean isDuplicated = groupRepository.existsByName(normalizedName);
+            boolean isDuplicated = groupRepository.existsByNormalizedName(normalizedName);
 
             Map<String, Object> response = new HashMap<>();
             response.put("available", !isDuplicated);

--- a/src/main/java/com/ktb/marong/controller/ManittoController.java
+++ b/src/main/java/com/ktb/marong/controller/ManittoController.java
@@ -7,6 +7,7 @@ import com.ktb.marong.dto.response.manitto.ManittoInfoResponseDto;
 import com.ktb.marong.dto.response.manitto.MissionStatusResponseDto;
 import com.ktb.marong.dto.response.mission.TodayMissionResponseDto;
 import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.repository.GroupRepository;
 import com.ktb.marong.security.CurrentUser;
 import com.ktb.marong.service.manitto.ManittoService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import java.util.Map;
 public class ManittoController {
 
     private final ManittoService manittoService;
+    private final GroupRepository groupRepository;
 
     /**
      * 마니또 상세 정보 조회 (그룹별, 시간대별)
@@ -34,6 +36,13 @@ public class ManittoController {
             @RequestParam Long groupId) {
 
         log.info("마니또 상세 정보 요청: userId={}, groupId={}", userId, groupId);
+
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", groupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+        }
 
         try {
             ManittoDetailResponseDto response = manittoService.getCurrentManittoDetail(userId, groupId);
@@ -109,6 +118,13 @@ public class ManittoController {
                     .body(ApiResponse.error("INVALID_GROUP_ID", "유효하지 않은 그룹 ID입니다."));
         }
 
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", groupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+        }
+
         try {
             MissionStatusResponseDto response = manittoService.getMissionStatus(userId, groupId);
 
@@ -172,6 +188,13 @@ public class ManittoController {
 
         log.info("새 미션 할당 요청: userId={}, groupId={}", userId, targetGroupId);
 
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(targetGroupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", targetGroupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+        }
+
         try {
             UserMission newMission = manittoService.assignNewMission(userId, targetGroupId);
 
@@ -209,6 +232,13 @@ public class ManittoController {
             @RequestParam Long groupId) {
 
         log.info("오늘 할당된 미션 조회: userId={}, groupId={}", userId, groupId);
+
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", groupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+        }
 
         try {
             TodayMissionResponseDto response = manittoService.getTodayAssignedMission(userId, groupId);
@@ -252,6 +282,13 @@ public class ManittoController {
             log.warn("잘못된 groupId: userId={}, groupId={}", userId, groupId);
             return ResponseEntity.badRequest()
                     .body(ApiResponse.error("INVALID_GROUP_ID", "유효하지 않은 그룹 ID입니다."));
+        }
+
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", groupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
         }
 
         try {

--- a/src/main/java/com/ktb/marong/controller/RecommendationController.java
+++ b/src/main/java/com/ktb/marong/controller/RecommendationController.java
@@ -3,6 +3,7 @@ package com.ktb.marong.controller;
 import com.ktb.marong.dto.response.common.ApiResponse;
 import com.ktb.marong.dto.response.recommendation.PlaceRecommendationResponseDto;
 import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.repository.GroupRepository;
 import com.ktb.marong.security.CurrentUser;
 import com.ktb.marong.service.recommendation.PlaceRecommendationService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecommendationController {
 
     private final PlaceRecommendationService placeRecommendationService;
+    private final GroupRepository groupRepository;
 
     /**
      * 장소 추천 조회 (밥집 & 카페) - 그룹별 분리
@@ -36,6 +38,13 @@ public class RecommendationController {
             log.warn("잘못된 groupId: {}", groupId);
             return ResponseEntity.badRequest()
                     .body(ApiResponse.error("INVALID_GROUP_ID", "유효하지 않은 그룹 ID입니다."));
+        }
+
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", groupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
         }
 
         try {

--- a/src/main/java/com/ktb/marong/domain/group/Group.java
+++ b/src/main/java/com/ktb/marong/domain/group/Group.java
@@ -17,7 +17,10 @@ public class Group {
     private Long id;
 
     @Column(nullable = false)
-    private String name;
+    private String name; // 표시용 이름 (공백 유지)
+
+    @Column(name = "normalized_name", nullable = false)
+    private String normalizedName; // 중복체크용 이름 (공백 제거, 소문자)
 
     @Column(columnDefinition = "TEXT")
     private String description;
@@ -31,6 +34,7 @@ public class Group {
     @Builder
     public Group(String name, String description, String inviteCode, String imageUrl) {
         this.name = name;
+        this.normalizedName = name.trim().replaceAll("\\s+", "").toLowerCase(); // 자동 정규화
         this.description = description;
         this.inviteCode = inviteCode;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/feed/PostResponseDto.java
@@ -46,10 +46,14 @@ public class PostResponseDto {
                 .build();
     }
 
-    public static PostResponseDto fromEntityWithRealTimeManitteeName(Post post, int likesCount, boolean isLiked, String realTimeManitteeName) {
+    /**
+     * 작성자 이름까지 커스터마이징 가능한 DTO 생성 메소드
+     */
+    public static PostResponseDto fromEntityWithRealTimeManitteeNameAndAuthor(Post post, int likesCount, boolean isLiked,
+                                                                              String realTimeManitteeName, String customAuthorName) {
         return PostResponseDto.builder()
                 .feedId(post.getId())
-                .author(post.getAnonymousSnapshotName())
+                .author(customAuthorName) // 커스터마이징된 작성자 이름 사용
                 .missionTitle(post.getMission().getTitle())
                 .manitteeName(realTimeManitteeName) // 실시간으로 결정된 마니띠 이름 사용
                 .content(post.getContent())

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -64,7 +64,7 @@ public enum ErrorCode {
     RECOMMENDATION_NOT_FOUND(404, "추천 정보를 찾을 수 없습니다."),
 
     // 그룹 관련 에러
-    MAX_GROUPS_EXCEEDED(400, "사용자당 최대 4개의 그룹까지 생성/가입할 수 있습니다."),
+    MAX_GROUPS_EXCEEDED(400, "사용자당 최대 6개의 그룹까지 생성/가입할 수 있습니다."),
     GROUP_MEMBER_LIMIT_EXCEEDED(400, "그룹당 최대 150명까지 가입할 수 있습니다."),
     GROUP_NAME_DUPLICATED(409, "동일한 그룹 이름이 이미 존재합니다."),
     INVITE_CODE_DUPLICATED(409, "초대코드가 이미 사용 중입니다. 다른 코드를 입력해주세요."),

--- a/src/main/java/com/ktb/marong/repository/GroupRepository.java
+++ b/src/main/java/com/ktb/marong/repository/GroupRepository.java
@@ -37,4 +37,9 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
      */
     @Query("SELECT g FROM Group g ORDER BY g.id DESC")
     Page<Group> findAllOrderByIdDesc(Pageable pageable);
+
+    /**
+     * 정규화된 그룹 이름으로 중복 확인
+     */
+    boolean existsByNormalizedName(String normalizedName);
 }

--- a/src/main/java/com/ktb/marong/repository/GroupRepository.java
+++ b/src/main/java/com/ktb/marong/repository/GroupRepository.java
@@ -28,6 +28,11 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     boolean existsByName(String name);
 
     /**
+     * 정규화된 그룹 이름으로 중복 확인
+     */
+    boolean existsByNormalizedName(String normalizedName);
+
+    /**
      * 초대 코드 중복 확인
      */
     boolean existsByInviteCode(String inviteCode);
@@ -37,9 +42,4 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
      */
     @Query("SELECT g FROM Group g ORDER BY g.id DESC")
     Page<Group> findAllOrderByIdDesc(Pageable pageable);
-
-    /**
-     * 정규화된 그룹 이름으로 중복 확인
-     */
-    boolean existsByNormalizedName(String normalizedName);
 }

--- a/src/main/java/com/ktb/marong/service/feed/FeedService.java
+++ b/src/main/java/com/ktb/marong/service/feed/FeedService.java
@@ -28,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -232,7 +234,11 @@ public class FeedService {
         // 3. 특정 그룹의 게시글만 조회
         Page<Post> postPage = postRepository.findAllByGroupIdOrderByCreatedAtDesc(groupId, pageable);
 
-        // 4. DTO 변환
+        // 4. 현재 주차 및 마니또 공개 시점 확인
+        int currentWeek = WeekCalculator.getCurrentWeek();
+        boolean isManittoRevealTime = isManittoRevealTime();
+
+        // 5. DTO 변환
         List<PostResponseDto> postDtos = postPage.getContent().stream()
                 .map(post -> {
                     int likeCount = postLikeRepository.countByPostId(post.getId());
@@ -244,15 +250,18 @@ public class FeedService {
                     // 실시간 마니띠 이름 결정
                     String realTimeManitteeName = determineManitteeNameForPost(post, groupId);
 
-                    return PostResponseDto.fromEntityWithRealTimeManitteeName(
-                            post, likeCount, isLiked, realTimeManitteeName);
+                    // 게시글 작성자 이름 결정
+                    String authorName = determineAuthorNameForPost(post, groupId, currentWeek, isManittoRevealTime);
+
+                    return PostResponseDto.fromEntityWithRealTimeManitteeNameAndAuthor(
+                            post, likeCount, isLiked, realTimeManitteeName, authorName);
                 })
                 .collect(Collectors.toList());
 
         log.info("게시글 목록 조회 완료: groupId={}, groupName={}, totalElements={}",
                 groupId, group.getName(), postPage.getTotalElements());
 
-        // 5. 그룹 정보 포함하여 응답 생성
+        // 6. 그룹 정보 포함하여 응답 생성
         return PostPageResponseDto.builder()
                 .page(page)
                 .pageSize(pageSize)
@@ -261,6 +270,94 @@ public class FeedService {
                 .groupName(group.getName())
                 .feeds(postDtos)
                 .build();
+    }
+
+    /**
+     * 게시글 작성자 이름 결정
+     * 규칙:
+     * 1. 현재 주차 게시글 + 마니또 공개 시점 이전 = 익명 이름만
+     * 2. 현재 주차 게시글 + 마니또 공개 시점 이후 = "그룹닉네임 (익명이름)" 형태
+     * 3. 지난 주차 게시글 = 항상 "그룹닉네임 (익명이름)" 형태 (해당 주차 공개 시점 이후)
+     */
+    private String determineAuthorNameForPost(Post post, Long groupId, int currentWeek, boolean isManittoRevealTime) {
+        try {
+            int postWeek = post.getWeek();
+            String anonymousName = post.getAnonymousSnapshotName();
+
+            // 케이스 1: 현재 주차 게시글이면서 마니또 공개 시점 이전
+            if (postWeek == currentWeek && !isManittoRevealTime) {
+                log.debug("현재 주차 비공개 시점 게시글: postId={}, week={}, 익명이름만 표시",
+                        post.getId(), postWeek);
+                return anonymousName;
+            }
+
+            // 케이스 2: 현재 주차 게시글이면서 마니또 공개 시점 이후
+            // 케이스 3: 지난 주차 게시글 (이미 해당 주차의 공개 시점이 지남)
+            if ((postWeek == currentWeek && isManittoRevealTime) || postWeek < currentWeek) {
+                // 게시글 작성자의 그룹 내 정보 조회
+                User postAuthor = post.getUser();
+                UserGroup authorUserGroup = userGroupRepository.findByUserIdAndGroupId(
+                        postAuthor.getId(), groupId).orElse(null);
+
+                String displayName;
+                if (authorUserGroup != null && authorUserGroup.hasGroupUserNickname()) {
+                    // 그룹 내 닉네임이 있는 경우
+                    displayName = authorUserGroup.getGroupUserNickname();
+                    log.debug("그룹 내 닉네임 사용: userId={}, groupNickname={}",
+                            postAuthor.getId(), displayName);
+                } else {
+                    // 그룹 내 닉네임이 없는 경우 카카오 실명 사용
+                    displayName = postAuthor.getNickname();
+                    log.debug("카카오 실명 사용: userId={}, kakaoName={}",
+                            postAuthor.getId(), displayName);
+                }
+
+                // "그룹닉네임 (익명이름)" 또는 "카카오실명 (익명이름)" 형태로 반환
+                String finalAuthorName = displayName + " (" + anonymousName + ")";
+
+                String caseDescription = (postWeek == currentWeek) ? "현재 주차 공개 시점" : "지난 주차";
+                log.debug("{} 게시글 작성자 이름 변경: postId={}, week={}, originalName={}, newName={}",
+                        caseDescription, post.getId(), postWeek, anonymousName, finalAuthorName);
+
+                return finalAuthorName;
+            }
+
+            // 케이스 4: 미래 주차 게시글 (일반적으로 발생하지 않아야 함)
+            log.warn("미래 주차 게시글 발견: postId={}, postWeek={}, currentWeek={}",
+                    post.getId(), postWeek, currentWeek);
+            return anonymousName;
+
+        } catch (Exception e) {
+            log.warn("게시글 작성자 이름 결정 실패, 기존 이름 사용: postId={}, error={}",
+                    post.getId(), e.getMessage());
+            // 오류 발생시 기존 익명 이름 사용
+            return post.getAnonymousSnapshotName();
+        }
+    }
+
+    /**
+     * 현재 시간이 마니또 공개 시점인지 확인
+     * 마니또 공개 시점: 금요일 오후 5시 이후 ~ 다음 주 월요일 오후 12시 이전
+     */
+    private boolean isManittoRevealTime() {
+        LocalDateTime now = LocalDateTime.now();
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+        int hour = now.getHour();
+
+        // 금요일 17시 이후인 경우
+        if (dayOfWeek == DayOfWeek.FRIDAY && hour >= 17) {
+            return true;
+        }
+        // 토요일, 일요일인 경우
+        else if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
+            return true;
+        }
+        // 월요일 12시 이전인 경우
+        else if (dayOfWeek == DayOfWeek.MONDAY && hour < 12) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/com/ktb/marong/service/group/GroupService.java
+++ b/src/main/java/com/ktb/marong/service/group/GroupService.java
@@ -220,6 +220,11 @@ public class GroupService {
         log.info("그룹 프로필 업데이트: userId={}, groupId={}, nickname={}",
                 userId, groupId, requestDto.getGroupUserNickname());
 
+        // 먼저 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            throw new CustomException(ErrorCode.GROUP_NOT_FOUND);
+        }
+
         // 사용자-그룹 관계 조회
         UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(userId, groupId)
                 .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND, "해당 그룹에 속하지 않은 사용자입니다."));
@@ -253,14 +258,16 @@ public class GroupService {
     public GroupDetailResponseDto getGroupDetail(Long userId, Long groupId) {
         log.info("그룹 상세 정보 조회: userId={}, groupId={}", userId, groupId);
 
+        // 먼저 그룹 존재 여부 확인
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
+
         // 사용자가 해당 그룹에 속해있는지 확인
         UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(userId, groupId)
                 .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND, "해당 그룹에 속하지 않은 사용자입니다."));
 
         // 현재 멤버 수 조회
         int currentMemberCount = userGroupRepository.countByGroupId(groupId);
-
-        Group group = userGroup.getGroup();
 
         // 응답 생성
         GroupDetailResponseDto response = GroupDetailResponseDto.builder()

--- a/src/main/java/com/ktb/marong/service/group/GroupService.java
+++ b/src/main/java/com/ktb/marong/service/group/GroupService.java
@@ -60,8 +60,9 @@ public class GroupService {
         GroupValidator.validateGroupName(requestDto.getGroupName());
         GroupValidator.validateGroupDescription(requestDto.getDescription());
 
-        // 그룹 이름 및 설명 정규화
-        String normalizedGroupName = GroupValidator.normalizeGroupName(requestDto.getGroupName());
+        // 그룹 이름 정규화 (중복체크용과 표시용 분리)
+        String normalizedGroupNameForCheck = GroupValidator.normalizeGroupName(requestDto.getGroupName()); // 중복체크용 (공백제거, 소문자)
+        String normalizedGroupNameForDisplay = GroupValidator.normalizeGroupNameForDisplay(requestDto.getGroupName()); // 저장용 (공백유지)
         String normalizedDescription = GroupValidator.normalizeGroupDescription(requestDto.getDescription());
 
         // 그룹 개수 제한 체크
@@ -75,8 +76,8 @@ public class GroupService {
         GroupNicknameValidator.validateNicknameFormat(requestDto.getGroupUserNickname());
         String normalizedNickname = GroupNicknameValidator.normalizeNickname(requestDto.getGroupUserNickname());
 
-        // 그룹 이름 중복 체크
-        if (groupRepository.existsByName(normalizedGroupName)) {
+        // 그룹 이름 중복 체크 (정규화된 이름으로 체크)
+        if (groupRepository.existsByNormalizedName(normalizedGroupNameForCheck)) {
             throw new CustomException(ErrorCode.GROUP_NAME_DUPLICATED);
         }
 
@@ -91,9 +92,9 @@ public class GroupService {
         // 사용자 프로필 이미지 업로드 처리
         String userProfileImageUrl = uploadUserProfileImage(groupUserProfileImage);
 
-        // 그룹 생성
+        // 그룹 생성 (표시용 이름으로 저장, 정규화된 이름은 엔티티에서 자동 생성)
         Group group = Group.builder()
-                .name(normalizedGroupName)
+                .name(normalizedGroupNameForDisplay) // 공백이 유지된 표시용 이름
                 .description(normalizedDescription)
                 .inviteCode(normalizedInviteCode)
                 .imageUrl(groupImageUrl)
@@ -112,12 +113,13 @@ public class GroupService {
 
         userGroupRepository.save(userGroup);
 
-        log.info("그룹 생성 완료: groupId={}, groupName={}, inviteCode={}, nickname={}",
-                savedGroup.getId(), normalizedGroupName, normalizedInviteCode, normalizedNickname);
+        log.info("그룹 생성 완료: groupId={}, displayName={}, normalizedName={}, inviteCode={}, nickname={}",
+                savedGroup.getId(), normalizedGroupNameForDisplay, normalizedGroupNameForCheck,
+                normalizedInviteCode, normalizedNickname);
 
         return CreateGroupResponseDto.builder()
                 .groupId(savedGroup.getId())
-                .groupName(savedGroup.getName())
+                .groupName(savedGroup.getName()) // 표시용 이름 반환
                 .inviteCode(normalizedInviteCode)
                 .build();
     }

--- a/src/main/java/com/ktb/marong/service/group/GroupService.java
+++ b/src/main/java/com/ktb/marong/service/group/GroupService.java
@@ -40,7 +40,7 @@ public class GroupService {
     private final UserRepository userRepository;
     private final FileUploadService fileUploadService;
 
-    private static final int MAX_GROUPS_PER_USER = 4;
+    private static final int MAX_GROUPS_PER_USER = 6;
     private static final int MAX_MEMBERS_PER_GROUP = 150;
 
     /**


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 그룹 가입 제한 개수 늘림
- 주차 지난 게시글 작성자 이름 조회되는 방식 수정
- 그룹 이름 중복 체크 API 구현
- 존재하지 않는 그룹 에러 분기 처리


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 그룹 가입 제한 개수가 원래는 4개였는데, 사용자 1명당 최대 6개까지 그룹 생성 및 삭제할 수 있도록 제한 늘림
- 이전에는 주차가 지난 게시글이든 주차가 진행 중인 게시글이든 구분 없이 게시글 작성자 이름은 "작성자 익명 이름 -> [마니띠 이름]" 형태로 조회되고 있었음.
  - 매칭 주기가 지난 후에는 사용자가 알아보기 쉽도록 게시글 작성자 이름을 바꿔서 보여줘야 할 필요성을 느낌
    - 따라서 주차가 지난 게시글의 작성자 이름은 "작성자 그룹 닉네임 (해당 주차에 마니또가 사용했던 익명 이름) -> [마니띠 이름]"의 형태로 조회되도록 수정
- 그룹 이름 중복 체크 API 구현
  - 이전에는 그룹 생성하는 API 내에서 그룹 이름 중복 체크를 하도록 구현함 -> 문제점: 불필요한 네트워크 요청 발생. 모든 데이터를 전송한 후 실패하면 다시 요청해야 하는 문제 발생함.
    - 따라서 기존 중복체크 로직을 유지하면서 실시간으로 중복체크하는 API를 추가로 구현
  - 그룹 이름 중복체크할 때, 띄어쓰기(공백)가 달라지면 같은 이름이라도 다른 이름이라고 간주하는 문제 발생
    - 예를 들어, "12조 그룹"과 "12조그룹"은 같은 이름이지만 공백이 달라서 다른 이름이라고 간주하는 문제가 발생하였음
      - 따라서 GroupValidator에서 그룹 이름 내에 있는 모든 공백을 제거하고 이름을 정규화 시킴. 그리고 GroupService의 createGroup 메소드에서 중복 체크와 저장을 분리함. 또한 ERD의 Groups 테이블에 normalized_name 칼럼을 추가함으로써 사용자에게는 입력한 원본 이름이 표시되지만 중복체크는 정규화된 이름으로 수행되어 실질적으로 같은 의미의 그룹명 중복을 방지하도록 구현
- API 요청을 보낼 때, 존재하지 않는 그룹을 조회할 시에 "존재하지 않는 그룹입니다"라는 에러 대신에 "해당 그룹에 속해있지 않습니다"라는 에러가 출력되고 있었음
  - 예를 들어, 존재하지 않는 그룹에 닉네임 중복 체크를 요청을 보내도 available이 true라고 출력됨.
    - 따라서 모든 API 요청 전에 먼저 그룹 존재 여부를 확인하는 로직을 넣어 존재하지 않는 그룹에 요청을 보냈을 때는 존재하지 않는 그룹이라는 에러 메시지가 출력될 수 있도록 처리함


## 관련 이슈
- Resolved: #
