### PR TITLE
[Feat] 마니또 기능 관련 유지보수

### DIFF
--- a/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
+++ b/src/main/java/com/ktb/marong/service/manitto/ManittoService.java
@@ -131,9 +131,14 @@ public class ManittoService {
                         .findAnonymousNameByUserIdAndGroupIdAndWeek(manittoUser.getId(), groupId, currentWeek)
                         .orElse("익명의 마니또");
 
+                // 그룹 닉네임이 없으면 카톡 실명으로 대체
+                String revealedManittoGroupNickname = (manittoUserGroup != null && manittoUserGroup.getGroupUserNickname() != null)
+                        ? manittoUserGroup.getGroupUserNickname()
+                        : manittoUser.getNickname();
+
                 revealedManitto = ManittoDetailResponseDto.RevealedManittoDto.builder()
                         .name(manittoUser.getNickname()) // 카카오 실명
-                        .groupNickname(manittoUserGroup != null ? manittoUserGroup.getGroupUserNickname() : null)
+                        .groupNickname(revealedManittoGroupNickname) // 그룹 닉네임 우선, 없으면 카톡 실명
                         .groupProfileImage(manittoUserGroup != null ? manittoUserGroup.getGroupUserProfileImageUrl() : null)
                         .anonymousName(manittoAnonymousName)
                         .build();
@@ -182,9 +187,14 @@ public class ManittoService {
                             .findAnonymousNameByUserIdAndGroupIdAndWeek(previousManittoUser.getId(), groupId, previousWeek)
                             .orElse("익명의 마니또");
 
+                    // 그룹 닉네임이 없으면 카톡 실명으로 대체
+                    String previousManittoGroupNickname = (previousManittoUserGroup != null && previousManittoUserGroup.getGroupUserNickname() != null)
+                            ? previousManittoUserGroup.getGroupUserNickname()
+                            : previousManittoUser.getNickname();
+
                     previousCycleManitto = ManittoDetailResponseDto.PreviousCycleManittoDto.builder()
                             .name(previousManittoUser.getNickname())
-                            .groupNickname(previousManittoUserGroup != null ? previousManittoUserGroup.getGroupUserNickname() : null)
+                            .groupNickname(previousManittoGroupNickname) // 그룹 닉네임 우선, 없으면 카톡 실명
                             .groupProfileImage(previousManittoUserGroup != null ? previousManittoUserGroup.getGroupUserProfileImageUrl() : null)
                             .anonymousName(previousManittoAnonymousName)
                             .build();
@@ -239,9 +249,14 @@ public class ManittoService {
                             .findAnonymousNameByUserIdAndGroupIdAndWeek(previousManittoUser.getId(), groupId, previousWeek)
                             .orElse("익명의 마니또");
 
+                    // 그룹 닉네임이 없으면 카톡 실명으로 대체
+                    String previousManittoGroupNickname = (previousManittoUserGroup != null && previousManittoUserGroup.getGroupUserNickname() != null)
+                            ? previousManittoUserGroup.getGroupUserNickname()
+                            : previousManittoUser.getNickname();
+
                     previousCycleManitto = ManittoDetailResponseDto.PreviousCycleManittoDto.builder()
                             .name(previousManittoUser.getNickname())
-                            .groupNickname(previousManittoUserGroup != null ? previousManittoUserGroup.getGroupUserNickname() : null)
+                            .groupNickname(previousManittoGroupNickname) // 그룹 닉네임 우선, 없으면 카톡 실명
                             .groupProfileImage(previousManittoUserGroup != null ? previousManittoUserGroup.getGroupUserProfileImageUrl() : null)
                             .anonymousName(previousManittoAnonymousName)
                             .build();


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 마니또 매칭 준비 기간(월요일 00시~12시) 분기 처리
- 마니또 정보 조회 시 설정된 그룹 닉네임 없으면 카카오 실명 출력되도록 통일


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 기존에는 마니또 공개기간(MANITTO_REVEAL)과 일반 활동기간(MANITTO_ACTIVE)로만 나누었는데, 마니또를 매칭하는 기간(월요일 00시~12시)를 추가하여 해당 기간 동안에는 지난주 마니또 정보만 조회될 수 있도록 분기 처리함 → MATCHING_PREPARATION
- 마니또 정보 조회 할 때, 설정된 그룹 닉네임이 없는 사용자는 응답 json 중 `groupNickname`에 카카오 실명이 출력되도록 수정함. 만약 설정된 그룹 닉네임이 있는 사용자는 `groupNickname`에 해당 그룹 닉네임이 출력되도록 함. 
  - 응답 json 중 name은 카카오 실명


## 관련 이슈
- Resolved: #
