### PR TITLE
[Feat] 미션 선택 및 그룹 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/ktb/marong/controller/MissionController.java
+++ b/src/main/java/com/ktb/marong/controller/MissionController.java
@@ -1,0 +1,102 @@
+package com.ktb.marong.controller;
+
+import com.ktb.marong.dto.request.mission.SelectMissionRequestDto;
+import com.ktb.marong.dto.response.common.ApiResponse;
+import com.ktb.marong.dto.response.mission.AvailableMissionResponseDto;
+import com.ktb.marong.dto.response.mission.SelectMissionResponseDto;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.repository.GroupRepository;
+import com.ktb.marong.security.CurrentUser;
+import com.ktb.marong.service.mission.MissionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/missions")
+public class MissionController {
+
+    private final MissionService missionService;
+    private final GroupRepository groupRepository;
+
+    /**
+     * 선택 가능한 미션 목록 조회
+     */
+    @GetMapping("/available")
+    public ResponseEntity<?> getAvailableMissions(
+            @CurrentUser Long userId,
+            @RequestParam Long groupId) {
+
+        log.info("선택 가능한 미션 목록 조회 요청: userId={}, groupId={}", userId, groupId);
+
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(groupId)) {
+            log.warn("존재하지 않는 그룹: groupId={}", groupId);
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+        }
+
+        try {
+            AvailableMissionResponseDto response = missionService.getAvailableMissions(userId, groupId);
+
+            return ResponseEntity.ok(ApiResponse.success(
+                    response,
+                    "available_missions_retrieved",
+                    null
+            ));
+        } catch (CustomException e) {
+            log.error("선택 가능한 미션 목록 조회 실패: userId={}, groupId={}, error={}",
+                    userId, groupId, e.getMessage());
+            return ResponseEntity.status(e.getErrorCode().getStatus())
+                    .body(ApiResponse.error(e.getErrorCode().name(), e.getMessage()));
+        } catch (Exception e) {
+            log.error("선택 가능한 미션 목록 조회 중 예상치 못한 오류: userId={}, groupId={}",
+                    userId, groupId, e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 오류입니다."));
+        }
+    }
+
+    /**
+     * 미션 선택
+     */
+    @PostMapping("/select")
+    public ResponseEntity<?> selectMission(
+            @CurrentUser Long userId,
+            @Valid @RequestBody SelectMissionRequestDto requestDto) {
+
+        log.info("미션 선택 요청: userId={}, missionId={}, groupId={}",
+                userId, requestDto.getMissionId(), requestDto.getGroupId());
+
+        // 그룹 존재 여부 확인
+        if (!groupRepository.existsById(requestDto.getGroupId())) {
+            log.warn("존재하지 않는 그룹: groupId={}", requestDto.getGroupId());
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("GROUP_NOT_FOUND", "존재하지 않는 그룹입니다."));
+        }
+
+        try {
+            SelectMissionResponseDto response = missionService.selectMission(userId, requestDto);
+
+            return ResponseEntity.ok(ApiResponse.success(
+                    response,
+                    "mission_selected",
+                    null
+            ));
+        } catch (CustomException e) {
+            log.error("미션 선택 실패: userId={}, missionId={}, groupId={}, error={}",
+                    userId, requestDto.getMissionId(), requestDto.getGroupId(), e.getMessage());
+            return ResponseEntity.status(e.getErrorCode().getStatus())
+                    .body(ApiResponse.error(e.getErrorCode().name(), e.getMessage()));
+        } catch (Exception e) {
+            log.error("미션 선택 중 예상치 못한 오류: userId={}, missionId={}, groupId={}",
+                    userId, requestDto.getMissionId(), requestDto.getGroupId(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 오류입니다."));
+        }
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/mission/GroupMission.java
+++ b/src/main/java/com/ktb/marong/domain/mission/GroupMission.java
@@ -1,0 +1,73 @@
+package com.ktb.marong.domain.mission;
+
+import com.ktb.marong.domain.group.Group;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "GroupMissions",
+        uniqueConstraints = @UniqueConstraint(name = "uq_group_mission_week",
+                columnNames = {"group_id", "mission_id", "week"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @Column(name = "max_assignable", nullable = false)
+    private Integer maxAssignable = 5;
+
+    @Column(name = "remaining_count", nullable = false)
+    private Integer remainingCount = 5;
+
+    @Builder
+    public GroupMission(Group group, Mission mission, Integer week,
+                        Integer maxAssignable, Integer remainingCount) {
+        this.group = group;
+        this.mission = mission;
+        this.week = week;
+        this.maxAssignable = maxAssignable != null ? maxAssignable : 5;
+        this.remainingCount = remainingCount != null ? remainingCount : 5;
+    }
+
+    /**
+     * 미션 선택 시 남은 인원 감소
+     */
+    public void decreaseRemainingCount() {
+        if (this.remainingCount > 0) {
+            this.remainingCount--;
+        }
+    }
+
+    /**
+     * 미션 선택 취소 시 남은 인원 증가
+     */
+    public void increaseRemainingCount() {
+        if (this.remainingCount < this.maxAssignable) {
+            this.remainingCount++;
+        }
+    }
+
+    /**
+     * 선택 가능한지 확인
+     */
+    public boolean isSelectable() {
+        return this.remainingCount > 0;
+    }
+}

--- a/src/main/java/com/ktb/marong/domain/mission/UserMission.java
+++ b/src/main/java/com/ktb/marong/domain/mission/UserMission.java
@@ -42,6 +42,9 @@ public class UserMission {
     @Column(name = "assigned_date", nullable = false)
     private LocalDate assignedDate;
 
+    @Column(name = "selection_type", nullable = false)
+    private String selectionType = "manual"; // auto: 자동할당, manual: 수동선택
+
     @CreationTimestamp
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -51,12 +54,13 @@ public class UserMission {
     private LocalDateTime updatedAt;
 
     @Builder
-    public UserMission(User user, Long groupId, Mission mission, Integer week, LocalDate assignedDate) {
+    public UserMission(User user, Long groupId, Mission mission, Integer week, LocalDate assignedDate, String selectionType) {
         this.user = user;
         this.groupId = groupId; // 파라미터로 받은 groupId 사용
         this.mission = mission;
         this.week = week;
         this.assignedDate = assignedDate != null ? assignedDate : LocalDate.now();
+        this.selectionType = selectionType != null ? selectionType : "manual";
     }
 
     /**
@@ -86,5 +90,19 @@ public class UserMission {
      */
     public boolean isCompleted() {
         return "completed".equals(this.status);
+    }
+
+    /**
+     * 자동 할당 미션인지 확인
+     */
+    public boolean isAutoAssigned() {
+        return "auto".equals(this.selectionType);
+    }
+
+    /**
+     * 수동 선택 미션인지 확인
+     */
+    public boolean isManuallySelected() {
+        return "manual".equals(this.selectionType);
     }
 }

--- a/src/main/java/com/ktb/marong/dto/request/mission/SelectMissionRequestDto.java
+++ b/src/main/java/com/ktb/marong/dto/request/mission/SelectMissionRequestDto.java
@@ -1,0 +1,18 @@
+package com.ktb.marong.dto.request.mission;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SelectMissionRequestDto {
+
+    @NotNull(message = "미션 ID는 필수입니다.")
+    private Long missionId;
+
+    @NotNull(message = "그룹 ID는 필수입니다.")
+    private Long groupId;
+}

--- a/src/main/java/com/ktb/marong/dto/response/mission/AvailableMissionResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/mission/AvailableMissionResponseDto.java
@@ -1,0 +1,49 @@
+package com.ktb.marong.dto.response.mission;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvailableMissionResponseDto {
+    private Long groupId;
+    private String groupName;
+    private String date;
+    private boolean canSelectToday; // 오늘 미션을 선택할 수 있는지 여부
+    private MissionSelectionStatus todaySelection; // 오늘 선택한 미션 정보
+    private List<AvailableMissionDto> availableMissions;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AvailableMissionDto {
+        private Long missionId;
+        private String title;
+        private String description;
+        private String difficulty;
+        private int currentSelections; // 오늘 현재까지 선택한 사람 수
+        private int maxSelections; // 최대 선택 가능 인원 (5명)
+        private int remainingSelections; // 남은 선택 가능 인원
+        private boolean alreadySelectedInWeek; // 이번 주차에 이미 선택했는지 여부
+        private boolean selectable; // 선택 가능 여부
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionSelectionStatus {
+        private Long missionId;
+        private String title;
+        private String description;
+        private String difficulty;
+        private String selectedAt;
+    }
+}

--- a/src/main/java/com/ktb/marong/dto/response/mission/SelectMissionResponseDto.java
+++ b/src/main/java/com/ktb/marong/dto/response/mission/SelectMissionResponseDto.java
@@ -1,0 +1,24 @@
+package com.ktb.marong.dto.response.mission;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SelectMissionResponseDto {
+    private Long missionId;
+    private String title;
+    private String description;
+    private String difficulty;
+    private Long groupId;
+    private LocalDate selectedDate;
+    private LocalDateTime selectedAt;
+    private String message;
+}

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
     INVITE_CODE_INVALID_CHARACTERS(400, "초대 코드는 영어와 숫자만 사용할 수 있습니다."),
     ALREADY_JOINED_GROUP(409, "이미 가입된 그룹입니다."),
     GROUP_NICKNAME_REQUIRED(400, "그룹 내 사용자 닉네임 설정이 필요합니다."),
+    CANNOT_LEAVE_GROUP_AS_OWNER(400, "그룹 소유자는 다른 멤버에게 소유권을 이전한 후 탈퇴할 수 있습니다."),
 
     // 닉네임 관련 에러
     NICKNAME_TOO_SHORT(400, "닉네임이 너무 짧습니다."),

--- a/src/main/java/com/ktb/marong/exception/ErrorCode.java
+++ b/src/main/java/com/ktb/marong/exception/ErrorCode.java
@@ -78,11 +78,17 @@ public enum ErrorCode {
     ALREADY_JOINED_GROUP(409, "이미 가입된 그룹입니다."),
     GROUP_NICKNAME_REQUIRED(400, "그룹 내 사용자 닉네임 설정이 필요합니다."),
 
-    // 닉네임 관련 에러 (새로 추가)
+    // 닉네임 관련 에러
     NICKNAME_TOO_SHORT(400, "닉네임이 너무 짧습니다."),
     NICKNAME_TOO_LONG(400, "닉네임이 너무 깁니다."),
     INVALID_NICKNAME_FORMAT(400, "유효하지 않은 닉네임 형식입니다."),
-    NICKNAME_DUPLICATED_IN_GROUP(409, "해당 그룹에서 이미 사용 중인 닉네임입니다.");
+    NICKNAME_DUPLICATED_IN_GROUP(409, "해당 그룹에서 이미 사용 중인 닉네임입니다."),
+
+    // 미션 선택 관련 에러
+    MISSION_SELECTION_NOT_FOUND(404, "미션 선택 정보를 찾을 수 없습니다."),
+    DAILY_MISSION_SELECTION_LIMIT_EXCEEDED(400, "하루에 한 개의 미션만 선택할 수 있습니다."),
+    MISSION_SELECTION_QUOTA_EXCEEDED(400, "해당 미션의 일일 선택 가능 인원이 마감되었습니다."),
+    MISSION_ALREADY_SELECTED_IN_WEEK(409, "이번 주차에 이미 선택한 미션입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/ktb/marong/repository/GroupMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/GroupMissionRepository.java
@@ -1,0 +1,38 @@
+package com.ktb.marong.repository;
+
+import com.ktb.marong.domain.mission.GroupMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GroupMissionRepository extends JpaRepository<GroupMission, Long> {
+
+    /**
+     * 특정 그룹의 특정 주차에 생성된 미션들 조회
+     */
+    @Query("SELECT gm FROM GroupMission gm JOIN FETCH gm.mission " +
+            "WHERE gm.group.id = :groupId AND gm.week = :week")
+    List<GroupMission> findByGroupIdAndWeek(@Param("groupId") Long groupId, @Param("week") Integer week);
+
+    /**
+     * 특정 그룹, 주차, 미션의 설정 조회
+     */
+    Optional<GroupMission> findByGroupIdAndMissionIdAndWeek(Long groupId, Long missionId, Integer week);
+
+    /**
+     * 특정 그룹의 특정 주차에 특정 미션이 생성되어 있는지 확인
+     */
+    boolean existsByGroupIdAndMissionIdAndWeek(Long groupId, Long missionId, Integer week);
+
+    /**
+     * 특정 그룹, 주차의 생성된 미션 개수 조회
+     */
+    @Query("SELECT COUNT(gm) FROM GroupMission gm " +
+            "WHERE gm.group.id = :groupId AND gm.week = :week")
+    long countGroupMissions(@Param("groupId") Long groupId, @Param("week") Integer week);
+}

--- a/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
+++ b/src/main/java/com/ktb/marong/repository/UserMissionRepository.java
@@ -111,17 +111,6 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
             @Param("week") Integer week);
 
     /**
-     * 특정 사용자의 특정 그룹에서 오늘 할당된 진행 중인 미션만 조회
-     */
-    @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.groupId = :groupId " +
-            "AND um.assignedDate = :date AND um.status = 'ing' AND um.week = :week")
-    List<UserMission> findTodaysInProgressMissionsByUserAndGroup(
-            @Param("userId") Long userId,
-            @Param("groupId") Long groupId,
-            @Param("date") LocalDate date,
-            @Param("week") Integer week);
-
-    /**
      * 특정 사용자의 특정 그룹에서 특정 상태의 미션 개수 조회
      */
     @Query("SELECT COUNT(um) FROM UserMission um WHERE um.user.id = :userId AND um.groupId = :groupId " +
@@ -131,4 +120,29 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
             @Param("groupId") Long groupId,
             @Param("week") Integer week,
             @Param("status") String status);
+
+    /**
+     * 특정 사용자의 특정 그룹에서 오늘 할당된 진행 중인 미션만 조회 (수동 선택 전용)
+     */
+    @Query("SELECT um FROM UserMission um WHERE " +
+            "(:userId IS NULL OR um.user.id = :userId) AND " +
+            "um.groupId = :groupId AND um.assignedDate = :date AND " +
+            "um.status = 'ing' AND um.week = :week AND um.selectionType = 'manual'")
+    List<UserMission> findTodaysInProgressMissionsByUserAndGroup(
+            @Param("userId") Long userId,
+            @Param("groupId") Long groupId,
+            @Param("date") LocalDate date,
+            @Param("week") Integer week);
+
+    /**
+     * 특정 그룹에서 오늘 특정 미션을 선택한 사용자 수 조회 (수동 선택만)
+     */
+    @Query("SELECT COUNT(um) FROM UserMission um WHERE um.groupId = :groupId AND " +
+            "um.mission.id = :missionId AND um.assignedDate = :date AND " +
+            "um.week = :week AND um.selectionType = 'manual'")
+    int countTodayMissionSelections(
+            @Param("groupId") Long groupId,
+            @Param("missionId") Long missionId,
+            @Param("date") LocalDate date,
+            @Param("week") Integer week);
 }

--- a/src/main/java/com/ktb/marong/service/mission/MissionService.java
+++ b/src/main/java/com/ktb/marong/service/mission/MissionService.java
@@ -1,0 +1,247 @@
+package com.ktb.marong.service.mission;
+
+import com.ktb.marong.common.util.WeekCalculator;
+import com.ktb.marong.domain.group.Group;
+import com.ktb.marong.domain.mission.GroupMission;
+import com.ktb.marong.domain.mission.Mission;
+import com.ktb.marong.domain.mission.UserMission;
+import com.ktb.marong.domain.user.User;
+import com.ktb.marong.dto.request.mission.SelectMissionRequestDto;
+import com.ktb.marong.dto.response.mission.AvailableMissionResponseDto;
+import com.ktb.marong.dto.response.mission.SelectMissionResponseDto;
+import com.ktb.marong.exception.CustomException;
+import com.ktb.marong.exception.ErrorCode;
+import com.ktb.marong.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+
+    private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
+    private final MissionRepository missionRepository;
+    private final GroupMissionRepository groupMissionRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final ManittoRepository manittoRepository;
+    private final UserMissionRepository userMissionRepository;
+
+    private static final int MAX_DAILY_SELECTIONS_PER_MISSION = 5;
+
+    /**
+     * 선택 가능한 미션 목록 조회 (주차별, 그룹별 완전 분리)
+     */
+    @Transactional(readOnly = true)
+    public AvailableMissionResponseDto getAvailableMissions(Long userId, Long groupId) {
+        log.info("선택 가능한 미션 목록 조회: userId={}, groupId={}", userId, groupId);
+
+        // 1. 기본 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
+
+        if (!userGroupRepository.existsByUserIdAndGroupId(userId, groupId)) {
+            throw new CustomException(ErrorCode.GROUP_NOT_FOUND, "해당 그룹에 속하지 않은 사용자입니다.");
+        }
+
+        // 2. 마니또 매칭 확인
+        int currentWeek = WeekCalculator.getCurrentWeek();
+        if (manittoRepository.findByManittoIdAndGroupIdAndWeek(userId, groupId, currentWeek).isEmpty()) {
+            throw new CustomException(ErrorCode.MANITTO_NOT_FOUND, "마니또 매칭이 되지 않아 미션을 선택할 수 없습니다.");
+        }
+
+        LocalDate today = LocalDate.now();
+
+        // 3. 오늘 이미 선택한 미션이 있는지 확인
+        List<UserMission> todayMissions = userMissionRepository.findTodaysInProgressMissionsByUserAndGroup(
+                userId, groupId, today, currentWeek);
+
+        boolean canSelectToday = todayMissions.isEmpty();
+        AvailableMissionResponseDto.MissionSelectionStatus todaySelection = null;
+
+        if (!canSelectToday) {
+            UserMission todayMission = todayMissions.get(0);
+            Mission selectedMission = todayMission.getMission();
+            todaySelection = AvailableMissionResponseDto.MissionSelectionStatus.builder()
+                    .missionId(selectedMission.getId())
+                    .title(selectedMission.getTitle())
+                    .description(selectedMission.getDescription())
+                    .difficulty(selectedMission.getDifficulty())
+                    .selectedAt(todayMission.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                    .build();
+        }
+
+        // 4. 이번 주차에 이미 선택한 미션들 조회
+        List<UserMission> weeklyMissions = userMissionRepository.findByUserIdAndGroupIdAndWeek(userId, groupId, currentWeek);
+        List<Long> selectedMissionIds = weeklyMissions.stream()
+                .filter(um -> "manual".equals(um.getSelectionType()))
+                .map(um -> um.getMission().getId())
+                .collect(Collectors.toList());
+
+        // 5. 해당 그룹의 현재 주차에 생성된 미션들만 조회
+        List<GroupMission> availableGroupMissions = groupMissionRepository.findByGroupIdAndWeek(groupId, currentWeek);
+
+        // 현재 주차에 미션을 생성하지 않은 경우 예외 처리
+        if (availableGroupMissions.isEmpty()) {
+            log.warn("현재 주차에 생성된 미션이 없음: groupId={}, week={}", groupId, currentWeek);
+            throw new CustomException(ErrorCode.MISSION_NOT_FOUND,
+                    String.format("현재 주차(%d)에 해당 그룹의 미션이 생성되지 않았습니다.", currentWeek));
+        }
+
+        List<AvailableMissionResponseDto.AvailableMissionDto> availableMissions = availableGroupMissions.stream()
+                .map(groupMission -> {
+                    Mission mission = groupMission.getMission();
+
+                    // 오늘 해당 미션을 선택한 사용자 수 조회
+                    int currentSelections = countTodaySelectionsForMission(groupId, mission.getId(), today, currentWeek);
+                    int maxSelections = groupMission.getMaxAssignable();
+                    int remainingSelections = Math.max(0, maxSelections - currentSelections);
+                    boolean alreadySelectedInWeek = selectedMissionIds.contains(mission.getId());
+                    boolean selectable = remainingSelections > 0 && !alreadySelectedInWeek && canSelectToday && groupMission.isSelectable();
+
+                    return AvailableMissionResponseDto.AvailableMissionDto.builder()
+                            .missionId(mission.getId())
+                            .title(mission.getTitle())
+                            .description(mission.getDescription())
+                            .difficulty(mission.getDifficulty())
+                            .currentSelections(currentSelections)
+                            .maxSelections(maxSelections)
+                            .remainingSelections(remainingSelections)
+                            .alreadySelectedInWeek(alreadySelectedInWeek)
+                            .selectable(selectable)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        log.info("선택 가능한 미션 목록 조회 완료: userId={}, groupId={}, week={}, availableCount={}, canSelectToday={}",
+                userId, groupId, currentWeek, availableMissions.size(), canSelectToday);
+
+        return AvailableMissionResponseDto.builder()
+                .groupId(groupId)
+                .groupName(group.getName())
+                .date(today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .canSelectToday(canSelectToday)
+                .todaySelection(todaySelection)
+                .availableMissions(availableMissions)
+                .build();
+    }
+
+    /**
+     * 미션 선택 (주차별, 그룹별 검증 강화)
+     */
+    @Transactional
+    public SelectMissionResponseDto selectMission(Long userId, SelectMissionRequestDto requestDto) {
+        log.info("미션 선택 요청: userId={}, missionId={}, groupId={}",
+                userId, requestDto.getMissionId(), requestDto.getGroupId());
+
+        // 1. 기본 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Group group = groupRepository.findById(requestDto.getGroupId())
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
+
+        Mission mission = missionRepository.findById(requestDto.getMissionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
+
+        if (!userGroupRepository.existsByUserIdAndGroupId(userId, requestDto.getGroupId())) {
+            throw new CustomException(ErrorCode.GROUP_NOT_FOUND, "해당 그룹에 속하지 않은 사용자입니다.");
+        }
+
+        // 2. 마니또 매칭 확인
+        int currentWeek = WeekCalculator.getCurrentWeek();
+        if (manittoRepository.findByManittoIdAndGroupIdAndWeek(userId, requestDto.getGroupId(), currentWeek).isEmpty()) {
+            throw new CustomException(ErrorCode.MANITTO_NOT_FOUND, "마니또 매칭이 되지 않아 미션을 선택할 수 없습니다.");
+        }
+
+        LocalDate today = LocalDate.now();
+
+        // 3. 해당 미션이 현재 주차에 생성되어 있는지 확인
+        if (!groupMissionRepository.existsByGroupIdAndMissionIdAndWeek(requestDto.getGroupId(), requestDto.getMissionId(), currentWeek)) {
+            throw new CustomException(ErrorCode.MISSION_NOT_FOUND,
+                    String.format("해당 미션(ID: %d)은 현재 주차(%d)에 생성되지 않았습니다.", requestDto.getMissionId(), currentWeek));
+        }
+
+        // 4. 오늘 이미 미션을 선택했는지 확인
+        List<UserMission> todayMissions = userMissionRepository.findTodaysInProgressMissionsByUserAndGroup(
+                userId, requestDto.getGroupId(), today, currentWeek);
+        if (!todayMissions.isEmpty()) {
+            throw new CustomException(ErrorCode.DAILY_MISSION_LIMIT_EXCEEDED, "오늘은 이미 미션을 선택했습니다.");
+        }
+
+        // 5. 이번 주차에 동일한 미션을 이미 선택했는지 확인
+        List<UserMission> weeklyMissions = userMissionRepository.findByUserIdAndGroupIdAndWeek(
+                userId, requestDto.getGroupId(), currentWeek);
+        boolean alreadySelectedInWeek = weeklyMissions.stream()
+                .filter(um -> "manual".equals(um.getSelectionType()))
+                .anyMatch(um -> um.getMission().getId().equals(requestDto.getMissionId()));
+
+        if (alreadySelectedInWeek) {
+            throw new CustomException(ErrorCode.MISSION_ALREADY_COMPLETED, "이번 주차에 이미 선택한 미션입니다.");
+        }
+
+        // 6. GroupMission에서 설정된 선택 가능 인원 확인
+        GroupMission groupMission = groupMissionRepository.findByGroupIdAndMissionIdAndWeek(
+                        requestDto.getGroupId(), requestDto.getMissionId(), currentWeek)
+                .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND, "해당 그룹에서 생성되지 않은 미션입니다."));
+
+        if (!groupMission.isSelectable()) {
+            throw new CustomException(ErrorCode.DAILY_MISSION_LIMIT_EXCEEDED,
+                    "해당 미션은 선택할 수 있는 인원이 마감되었습니다.");
+        }
+
+        // 7. 미션 선택 및 저장
+        UserMission userMission = UserMission.builder()
+                .user(user)
+                .groupId(requestDto.getGroupId())
+                .mission(mission)
+                .week(currentWeek)
+                .assignedDate(today)
+                .selectionType("manual")
+                .build();
+
+        UserMission savedMission = userMissionRepository.save(userMission);
+
+        // 8. GroupMission의 remaining_count 감소
+        groupMission.decreaseRemainingCount();
+        groupMissionRepository.save(groupMission);
+
+        log.info("미션 선택 완료: userId={}, missionId={}, groupId={}, userMissionId={}, remainingCount={}",
+                userId, requestDto.getMissionId(), requestDto.getGroupId(), savedMission.getId(), groupMission.getRemainingCount());
+
+        return SelectMissionResponseDto.builder()
+                .missionId(mission.getId())
+                .title(mission.getTitle())
+                .description(mission.getDescription())
+                .difficulty(mission.getDifficulty())
+                .groupId(requestDto.getGroupId())
+                .selectedDate(today)
+                .selectedAt(savedMission.getCreatedAt())
+                .message("미션 선택이 완료되었습니다.")
+                .build();
+    }
+
+    /**
+     * 오늘 특정 미션을 선택한 사용자 수 조회 (그룹별)
+     */
+    private int countTodaySelectionsForMission(Long groupId, Long missionId, LocalDate date, Integer week) {
+        List<UserMission> todaySelections = userMissionRepository.findTodaysInProgressMissionsByUserAndGroup(
+                null, groupId, date, week); // userId를 null로 하여 모든 사용자 조회
+
+        return (int) todaySelections.stream()
+                .filter(um -> um.getMission().getId().equals(missionId))
+                .filter(um -> "manual".equals(um.getSelectionType())) // 수동 선택만 카운트
+                .count();
+    }
+}


### PR DESCRIPTION
## 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 사용자가 미션 선택할 수 있는 기능 추가
- 선택 가능한 미션 목록 조회 기능 추가 
- remaining_time 기준 변경
- 그룹 탈퇴 기능 추가


## PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 미션 선택 API 구현 `POST /api/missions/select`
  - UserMissions 테이블에 selection_type 컬럼 추가 → 기존에 미션 자동할당 할 때 사용하던 데이터는 auto, 미션 선택으로 바뀐 후부터는 manual
  - GroupMissions 테이블에 week 칼럼 추가 → 그룹별, 주차별 완전 분리된 채로 미션 선택 기능 동작할 수 있도록 함
  - 사용자가 하루에 1개씩 미션 선택할 수 있음 → 각각 미션마다 선택할 수 있는 개수는 5개로 제한 → 하나의 미션을 이미 5명의 사용자가 선택했으면 해당 미션은 해당 날에는 더이상 선택할 수 없음
  - 기존과 마찬가지로 하나의 주차 안에서 같은 미션 중복 수행은 불가
- 선택 가능한 미션 목록 조회 API 구현 `GET /api/missions/available?{groupId}`
  - 응답 DTO에서 `canSelectToday`가 true이면 해당 날짜에 미션 선택 가능, `todaySelection`에는 오늘 선택한 미션 내용 출력, `availableMissions`에서 `currentSelections`는 오늘 현재까지 해당 미션을 선택한 사람 수, `maxSelections`는 해당 미션 최대 선택 가능한 개수이므로 default 5, `remainingSelections`는 남은 선택 가능 인원, `alreadySelectedInWeek`는 해당 미션을 이번주에 선택했었는지, `selectable`는 해당 미션 선택 가능 여부를 각각 나타냄
- remaining_time 기준 변경
  - 기존에는 요일에 관계없이 항상 가장 가까운 월요일 오후 12시를 기준으로 함
    - 일반 활동 기간(월요일 오후 12시~금요일 오후 5시)에는 마니또 정체가 공개되는 해당 주의 금요일 오후 5시를 기준으로 reamining_time 설정
    - 그 이외의 기간인 마니또 공개기간과 매칭 준비 기간(금요일 오후 5시~월요일 오후 12시)에는 새로운 마니또 매칭이 이루어지는 가장 가까운 월요일 오후 12시를 기준으로 reamining_time을 설정
- 그룹 탈퇴 API 구현
  - 그룹을 만든 사람, 즉 그룹 소유자는 그룹 탈퇴 불가능 → 만약 그룹 소유자가 탈퇴하고 싶다면 그룹 소유권을 다른 사람에게 이전 후에 탈퇴 가능 → (아직 그룹 소유권 이전 기능은 없음)



## 관련 이슈
- Resolved: #
